### PR TITLE
add(backend): Add recent works api

### DIFF
--- a/backend/otodb/api/work.py
+++ b/backend/otodb/api/work.py
@@ -132,14 +132,7 @@ def random(request: HttpRequest, n: int = 1):
 
 @work_router.get('recent', response=list[WorkSchema])
 def recent(request: HttpRequest, n: int = 1):
-	sources = (
-    	WorkSource.active_objects
-			.select_related("media")
-    		.filter(media__rating=Rating.GENERAL).order_by('-published_date')
-            # .distinct('media')[:n] -- need postgres only
-        )[:n]
-
-	return 200, { s.media for s in sources }
+    return MediaWork.active_objects.filter(rating=Rating.GENERAL).order_by("-id")[:n]
 
 class SlimWorkSchema(ModelSchema):
     id: int


### PR DESCRIPTION
I was very surprised that current works has nothing timestamp for e.g. `created_at` and `updated_at`. 
I make this route by sorting by source. 

And i don't familar django framework / or restriction sqlite3, i don't came up with good way to get sources distinctly. i think it's better we use same db on local and prod env for developing confusion. fortunately we can use docker.

Fixes #142