### PR TITLE
Improve tag suggestions UI/UX

### DIFF
--- a/frontend/src/lib/TagField.svelte
+++ b/frontend/src/lib/TagField.svelte
@@ -53,6 +53,6 @@
 
 <style>
 	ul {
-		background-color: var(--otodb-color-bg-primary);
+		background-color: var(--otodb-color-bg-faint);
 	}
 </style>

--- a/frontend/src/lib/TagSuggestionResults.svelte
+++ b/frontend/src/lib/TagSuggestionResults.svelte
@@ -1,22 +1,77 @@
 <script lang="ts">
-	let { suggestions, onclick, type } = $props();
+	import { WorkTagPresentationColours } from './enums';
+	import { makeTagDisplayName } from './api';
+
+	let { suggestions, selectedIndex, onclick, onhover, type, query = '' } = $props();
+
+	const highlightMatch = (text: string, query: string) => {
+		const displayText = makeTagDisplayName(text);
+		if (!query) return { before: displayText, match: '', after: '' };
+		const index = text.toLowerCase().indexOf(query.toLowerCase());
+		if (index === -1) return { before: displayText, match: '', after: '' };
+		const result = {
+			before: displayText.slice(0, index),
+			match: displayText.slice(index, index + query.length),
+			after: displayText.slice(index + query.length)
+		};
+		return result;
+	};
+
+	const getTagStyle = (category: number) => {
+		return type === 'work' && category !== 0
+			? `color: ${WorkTagPresentationColours[category]}`
+			: '';
+	};
 </script>
 
 {#each suggestions as t, i (i)}
 	<li
-		class="bg-otodb-bg-fainter hover:bg-otodb-bg-faint flex w-full justify-between gap-10 px-2 py-1"
+		class:bg-otodb-bg-fainter={selectedIndex === i}
+		class:bg-otodb-bg-faint={selectedIndex !== i}
 	>
-		<a class="max-w-60 cursor-pointer" href={null} onclick={(...rest) => onclick(t, ...rest)}
-			>{t.aliased_to ? `${t.name} → ${t.aliased_to.name}` : t.name}
-			{#if t.slug !== t.name}<address class="inline">
-					({t.slug}<!-- TODO extend lang prefs to song tags -->{#if type === 'work'}{[
-							'',
-							...t.lang_prefs
-						]
-							.map((p) => p.tag)
-							.join(', ')}{/if})
-				</address>{/if}</a
+		<a
+			href="/tag/{t.aliased_to?.slug || t.slug}"
+			class="flex w-full cursor-pointer justify-between gap-10 px-2 py-1 no-underline"
+			onmouseenter={() => onhover(i)}
+			onclick={(e) => {
+				if (e.button === 0) {
+					e.preventDefault();
+					onclick(t, e);
+				}
+			}}
 		>
-		<span>{t.n_instance}</span>
+			<span class="max-w-60">
+				{#if t.aliased_to}
+					{@const parts = highlightMatch(t.name, query)}
+					{@const aliasedParts = highlightMatch(t.aliased_to.name, query)}
+					<span style={getTagStyle(t.aliased_to.category)}>
+						{parts.before}<strong>{parts.match}</strong>{parts.after}
+					</span>
+					<span>→</span>
+					<span style={getTagStyle(t.aliased_to.category)}>
+						{aliasedParts.before}<strong>{aliasedParts.match}</strong
+						>{aliasedParts.after}
+					</span>
+				{:else}
+					{@const parts = highlightMatch(t.name, query)}
+					<span style={getTagStyle(t.category)}>
+						{parts.before}<strong>{parts.match}</strong>{parts.after}
+					</span>
+				{/if}
+				{#if t.slug !== t.name}
+					{@const slugParts = highlightMatch(t.slug, query)}
+					<address class="inline">
+						({slugParts.before}<strong>{slugParts.match}</strong
+						>{slugParts.after}<!-- TODO extend lang prefs to song tags -->{#if type === 'work'}{[
+								'',
+								...t.lang_prefs
+							]
+								.map((p) => p.tag)
+								.join(', ')}{/if})
+					</address>
+				{/if}
+			</span>
+			<span>{t.n_instance}</span>
+		</a>
 	</li>
 {/each}

--- a/frontend/src/lib/TagsField.svelte
+++ b/frontend/src/lib/TagsField.svelte
@@ -16,6 +16,8 @@
 
 	let textarea: HTMLTextAreaElement;
 	let suggestions = $state<any[]>([]);
+	let selectedIndex = $state(0);
+	let lastQuery = $state('');
 
 	const getWordAtPos = (str: string, pos: number) => {
 		let start = [...str.slice(0, pos)].reverse().join('').search(/\s/g);
@@ -34,13 +36,18 @@
 		const query = getWordAtPos(textarea.value, textarea.selectionStart).word;
 		if (query === '') {
 			suggestions = [];
+			selectedIndex = 0;
+			lastQuery = '';
 			return;
 		}
+		if (query === lastQuery) return;
+		lastQuery = query;
 		const { data } = await client.GET(endpoint, {
 			params: { query: { query, limit: 10, resolve_aliases: false } }
 		});
 		if (!data) return;
 		suggestions = data.items;
+		selectedIndex = 0;
 	});
 
 	const updateValue = () => {
@@ -54,6 +61,36 @@
 		];
 	};
 
+	const selectTag = (tag: any) => {
+		textarea.value = replaceWordAtPos(
+			textarea.value,
+			textarea.selectionStart,
+			tag.aliased_to ? tag.aliased_to.slug : tag.slug + ' '
+		);
+		suggestions = [];
+		selectedIndex = 0;
+		updateValue();
+		textarea.focus();
+	};
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		if (!suggestions.length) return;
+
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			selectedIndex = (selectedIndex + 1) % suggestions.length;
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			selectedIndex = selectedIndex <= 0 ? suggestions.length - 1 : selectedIndex - 1;
+		} else if (e.key === 'Enter' && suggestions.length > 0) {
+			e.preventDefault();
+			selectTag(suggestions[selectedIndex]);
+		} else if (e.key === 'Escape') {
+			suggestions = [];
+			selectedIndex = 0;
+		}
+	};
+
 	onMount(() => {
 		if (value) {
 			textarea.value = value.join(' ');
@@ -63,6 +100,7 @@
 
 <span role="none">
 	<textarea
+		onkeydown={handleKeyDown}
 		onkeyup={() => {
 			updateValue();
 			search();
@@ -78,20 +116,16 @@
 			use:clickOutside
 			onOutclick={() => {
 				suggestions = [];
+				selectedIndex = 0;
 			}}
 		>
 			<TagSuggestionResults
 				{suggestions}
-				onclick={(t) => {
-					textarea.value = replaceWordAtPos(
-						textarea.value,
-						textarea.selectionStart,
-						t.aliased_to ? t.aliased_to.slug : t.slug + ' '
-					);
-					suggestions = [];
-					updateValue();
-				}}
+				{selectedIndex}
+				onclick={(t) => selectTag(t)}
+				onhover={(index) => (selectedIndex = index)}
 				{type}
+				query={lastQuery}
 			/>
 		</ul>
 	{/if}


### PR DESCRIPTION
- Colors tags according to their category
- Highlights the partial search match
- Keyboard navigation
	- up/down to cycle in list
	- enter to confirm selection
- Add hyperlink to tag page
	- ignores LMB
- Uses `makeTagDisplayName` to visually hide underscores in suggestion results