### PR TITLE
Fix no parent select

### DIFF
--- a/frontend/src/routes/tag/[tag_slug]/edit/+page.svelte
+++ b/frontend/src/routes/tag/[tag_slug]/edit/+page.svelte
@@ -36,6 +36,7 @@
 	);
 	$effect(() => {
 		if (prev_n_parents === 0 && parents.length > 0) primary = 0;
+		if (parents.length === 0) primary = -1;
 		prev_n_parents = parents.length;
 	});
 


### PR DESCRIPTION
Fix for https://github.com/otoDB/otoDB/commit/6f230c334968ba6089fc092ddd2c8b156f3e5954 when all parents are removed to put the select dropdown into a valid state