### PR TITLE
Support SoundCloud URL slug in `work/query_external`

### DIFF
--- a/backend/otodb/api/work.py
+++ b/backend/otodb/api/work.py
@@ -1,5 +1,3 @@
-import re
-
 from typing import List, Literal
 
 from django.http import HttpRequest
@@ -78,27 +76,10 @@ def query_external(
 	if url:
 		work = get_object_or_404(WorkSource.active_objects, url=url)
 	elif platform and id:
-		platform_str = Platform.from_str(platform)
-		match platform_str:
-			case Platform.SOUNDCLOUD:
-				if re.fullmatch(r'[^/]+/[^/]+', id):  # URL slug e.g. `user/track`
-					work = get_object_or_404(
-						WorkSource.active_objects,
-						platform=Platform.SOUNDCLOUD,
-						url='https://soundcloud.com/' + id,
-					)
-				else:  # else numeric ID e.g. `123456`
-					work = get_object_or_404(
-						WorkSource.active_objects,
-						platform=Platform.SOUNDCLOUD,
-						source_id=id,
-					)
-			case _:
-				work = get_object_or_404(
-					WorkSource.active_objects,
-					platform=platform_str,
-					source_id=id,
-				)
+		work = get_object_or_404(
+			WorkSource.active_objects.filter(platform=Platform.from_str(platform)),
+			Q(source_id=id) | Q(url__endswith=id),
+		)
 	else:
 		# TODO: raise a more specific error
 		raise ValueError(


### PR DESCRIPTION
close #322 

Test
1. Add https://soundcloud.com/hxudmdc1lxrs/virus-storm
2. `http "http://127.0.0.1:8000/api/work/query_external" platform=="soundcloud" id=="hxudmdc1lxrs/virus-storm"`