### PR TITLE
Allow BV_p[numeric ID] to coexist with BV

### DIFF
--- a/backend/otodb/common.py
+++ b/backend/otodb/common.py
@@ -89,7 +89,9 @@ platform_extractors: list[tuple[Platform, type[InfoExtractor]]] = [
 make_video_url = {
 	Platform.YOUTUBE: lambda s, uid=None: f'https://youtube.com/watch?v={s}',
 	Platform.NICONICO: lambda s, uid=None: f'https://nicovideo.jp/watch/{s}',
-	Platform.BILIBILI: lambda s, uid=None: f'https://www.bilibili.com/video/{s + '/' if '_p' not in s else s[:s.index('_p')] + '/' + '?p=' + s[s.index('_p') + 2:]}',
+	Platform.BILIBILI: lambda s, uid=None: (
+		f'https://www.bilibili.com/video/{s + "/" if "_p" not in s else s[: s.index("_p")] + "/" + "?p=" + s[s.index("_p") + 2 :]}'
+	),
 	Platform.SOUNDCLOUD: lambda s, uid=None: s,  # TODO
 	Platform.TWITTER: lambda s, uid=None: (
 		f'https://twitter.com/{uid}/status/{s}'
@@ -214,9 +216,7 @@ def process_video_info(full_info, link=None):
 			case Platform.BILIBILI:
 				if 'p' not in furl(info['webpage_url']).args:
 					info['id'] = _clean_bilibili_source_id(info['id'])
-					title_chapter_mark = info['title'].find(
-						' p01'
-					) 
+					title_chapter_mark = info['title'].find(' p01')
 					if title_chapter_mark != -1:
 						info['title'] = info['title'][:title_chapter_mark]
 					info['webpage_url'] = make_video_url[info['extractor']](info['id'])


### PR DESCRIPTION
closes #341 
This does mean p=1 will be separate from without p parameter at all and that's probably okay
Did not defensively program and test for nonexistent `p` but it should be handled by yt-dlp