### PR TITLE
Redirect to tag edit page on alias operation

### DIFF
--- a/backend/otodb/api/tag.py
+++ b/backend/otodb/api/tag.py
@@ -245,7 +245,11 @@ def tag_route_switch(work_route: Route, song_route: Route):
 	return decorator
 
 
-@tag_router.post('alias', auth=django_auth)
+class AliasResponse(Schema):
+	merged_slug: str
+
+
+@tag_router.post('alias', auth=django_auth, response=AliasResponse)
 @user_is_trusted
 @tag_route_switch(Route.TAGWORK_ALIAS, Route.SONGTAG_ALIAS)
 def alias_tags(
@@ -275,7 +279,7 @@ def alias_tags(
 			if tag.can_be_deleted:
 				tag.delete()
 
-	return {'merged_slug': into.slug}
+	return AliasResponse(merged_slug=into.slug)
 
 
 @tag_router.delete('tag', auth=django_auth, response={200: None, 400: None})

--- a/frontend/src/lib/schema.d.ts
+++ b/frontend/src/lib/schema.d.ts
@@ -2107,6 +2107,11 @@ export interface components {
              */
             lang: number;
         };
+        /** AliasResponse */
+        AliasResponse: {
+            /** Merged Slug */
+            merged_slug: string;
+        };
         /** WikiPageMDSchema */
         WikiPageMDSchema: {
             /** Page */
@@ -3922,7 +3927,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["AliasResponse"];
+                };
             };
         };
     };

--- a/frontend/src/routes/tag/alias/+page.svelte
+++ b/frontend/src/routes/tag/alias/+page.svelte
@@ -21,7 +21,7 @@
 			params: { query: { into_tag: selected, delete: del } },
 			body: tags
 		});
-		if (!error) goto(`/tag/${data.merged_slug}`, { invalidateAll: true });
+		if (!error) goto(`/tag/${data.merged_slug}/edit`, { invalidateAll: true });
 	};
 </script>
 


### PR DESCRIPTION
This makes more sense to me since often after aliasing/merging tags, seeing the works associated is not really relevant, and more likely you want to modify the tag data or language display