### PR TITLE
Tweak Dependabot to always trigger update PR

### DIFF
--- a/.github/workflows/rename-ytdlp-patch.yml
+++ b/.github/workflows/rename-ytdlp-patch.yml
@@ -24,7 +24,7 @@ jobs:
           OLD_PATCH=$(ls backend/patches/yt-dlp+*.patch 2>/dev/null | head -1)
           [ -z "$OLD_PATCH" ] && { echo "No patch file found"; exit 0; }
 
-          NEW_VERSION=$(grep -oP 'yt-dlp\[default\](>=|==)\K[0-9.]+' backend/pyproject.toml)
+          NEW_VERSION=$(grep -oP 'yt-dlp\[default\]==\K[0-9.]+' backend/pyproject.toml)
           NEW_PATCH="backend/patches/yt-dlp+${NEW_VERSION}.patch"
 
           [ "$OLD_PATCH" = "$NEW_PATCH" ] && { echo "Already up to date"; exit 0; }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "orjson>=3.11.5",
 
 	# has corresponding patch in patches/
-    "yt-dlp[default]>=2026.3.3",
+    "yt-dlp[default]==2026.3.3",
 
     # included for legacy migrations
     "django-simple-history>=3.10.1",


### PR DESCRIPTION
More correct anyways since now this means the patch file version always matches.