### PR TITLE
Mark tag instances as source when applicable

### DIFF
--- a/backend/otodb/api/tag.py
+++ b/backend/otodb/api/tag.py
@@ -29,6 +29,7 @@ from otodb.models import (
 	TagWorkLangPreference,
 	TagWorkMediaConnection,
 	TagWorkCreatorConnection,
+	TagWorkInstance,
 	TagWorkParenthood,
 )
 from otodb.models.enums import (
@@ -468,17 +469,28 @@ def update(
 		except MediaSong.DoesNotExist:
 			tag.category = WorkTagCategory.SONG
 			song = MediaSong.objects.create(work_tag=tag, **song_payload.dict())
+	# If category changed from source to creator or media, mark all instances with used_as_source
+	if tag.category == WorkTagCategory.SOURCE and payload.category in (
+		WorkTagCategory.CREATOR,
+		WorkTagCategory.MEDIA,
+	):
+		TagWorkInstance.objects.filter(work_tag=tag).update(used_as_source=True)
+
+	# Remove creator connections if no longer a creator
 	if (
 		tag.category == WorkTagCategory.CREATOR
 		and payload.category != WorkTagCategory.CREATOR
 	):
 		TagWorkCreatorConnection.objects.filter(tag=tag).delete()
+
+	# Remove media connections and media type if no longer media
 	if (
 		tag.category == WorkTagCategory.MEDIA
 		and payload.category != WorkTagCategory.MEDIA
 	):
 		TagWorkMediaConnection.objects.filter(tag=tag).delete()
 		tag.set_media_type([])
+
 	if payload.category == WorkTagCategory.MEDIA:
 		if payload.media_type:
 			tag.category = payload.category


### PR DESCRIPTION
Feature request from Discord: https://discord.com/channels/1393616615395954750/1393616616247525402/1481080910983074006

> is there an easy way to change tag type to media, while preserving existing entries as a source?
<https://otodb.net/work/11739>
<https://otodb.net/tag/scott_the_woz>

This PR implements it for both changing to tag type to media or creator. Doesn't make sense to me to do this for songs.