### PR TITLE
Add Claude Code and GitHub Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# GitHub Copilot Instructions for otoDB
+
+## Project Overview
+
+otoDB is a full-stack media management application:
+
+- **Backend**: Django 6 + Django Ninja (Python 3.14+)
+- **Frontend**: SvelteKit 2 + Svelte 5 + TypeScript + Tailwind CSS 4
+- **Browser Extension**: Chrome/Firefox extension
+
+## Backend (Python/Django)
+
+- Use Django Ninja for all new API endpoints; follow the router pattern in `otodb/api/`
+- Schema classes go in the same file as their router (or a `schemas.py` sibling)
+- Use `psycopg` (not `psycopg2`) for any raw DB access
+- Async views are supported via Granian ASGI server
+- Task queuing uses `django-tasks-rq`; enqueue via `django_tasks`
+- ORM: prefer `select_related`/`prefetch_related` over N+1 queries
+- Follow ruff formatting and linting rules (4-space indentation, standard Python style)
+
+## Frontend (TypeScript/Svelte)
+
+- Use **Svelte 5 runes** exclusively: `$state`, `$derived`, `$effect`, `$props`, `$bindable`
+- Do NOT use Svelte 4 reactive declarations (`$:`) or stores (`writable`, `readable`)
+- API calls on the server side must use the SvelteKit-injected `fetch` (passed from `load` functions)
+- API types are generated from the OpenAPI schema — use them from `$lib/api/`
+- Tailwind CSS 4 utility classes for all styling; avoid inline styles
+- Components go in `src/lib/components/`; utilities in `src/lib/`
+- Format with Prettier and lint with ESLint before committing
+
+## General Guidelines
+
+- Indent with **tabs** (displayed as 4 spaces) — see `.editorconfig`
+- YAML files use 2-space indentation
+- UTF-8 encoding, LF line endings, final newline required
+- Write tests for new backend API endpoints using pytest fixtures in `tests/conftest.py`
+- Prefer editing existing files over creating new ones
+- Keep changes minimal and focused; avoid refactoring unrelated code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# otoDB - Claude Code Instructions
+
+## Project Overview
+
+otoDB is a full-stack application for managing media works. It consists of:
+
+- **Backend**: Django 6 + Django Ninja REST API (Python 3.14+, managed by `uv`)
+- **Frontend**: SvelteKit 2 + Svelte 5 + TypeScript + Tailwind CSS 4 (managed by `bun`)
+- **Browser Extension**: Chrome/Firefox extension (managed by `bun`/`npm`)
+
+## Architecture
+
+- Backend exposes a REST API at `/api/` documented as OpenAPI at `/api/openapi.json`
+- Frontend uses generated TypeScript types from the OpenAPI schema (`bunx openapi-typescript`)
+- Server-side SvelteKit fetch must use the injected `fetch` to maintain session cookies
+- PostgreSQL 17 in production, SQLite supported for development/testing
+
+## Development Commands
+
+### Backend (`backend/`)
+
+```bash
+uv sync                        # Install dependencies
+uv run manage.py runserver     # Dev server
+uv run pytest -v --tb=short    # Run tests
+uvx ruff format .              # Format code
+uvx ruff check .               # Lint code
+uv run _setup.py               # Initialize DB and create admin user
+```
+
+### Frontend (`frontend/`)
+
+```bash
+bun install                    # Install dependencies
+bun run dev                    # Dev server
+bun run build                  # Production build
+bun run check                  # Type check
+bun run lint                   # Check formatting + lint (Prettier + ESLint)
+bun run format                 # Auto-format
+bun run storybook              # Storybook dev server
+```
+
+### Browser Extension (`browser-extension/`)
+
+```bash
+bun run build:chrome           # Build Chrome extension
+bun run build:firefox          # Build Firefox extension
+```
+
+## Code Style
+
+### Python (Backend)
+
+- Formatter/linter: **ruff** (configured in `pyproject.toml`)
+- Pre-commit hooks run ruff format and ruff check automatically
+- Follow existing patterns in `otodb/api/` for new API endpoints using Django Ninja routers
+
+### TypeScript/Svelte (Frontend)
+
+- Formatter: **Prettier** (`.prettierrc`)
+- Linter: **ESLint** (`eslint.config.js`)
+- Use Svelte 5 runes syntax (`$state`, `$derived`, `$effect`, `$props`)
+- Tailwind CSS 4 for styling
+
+## Testing
+
+### Backend
+
+- Framework: pytest + pytest-django
+- Fixtures in `tests/conftest.py` (use `work_client`, `tag_client`, `auth_client` for authenticated API tests)
+- Run against SQLite locally; CI also runs against PostgreSQL 17
+
+### Frontend
+
+- Unit tests: Vitest
+- E2E tests: Playwright
+
+## Environment Setup
+
+- Backend: copy `backend/.env.example` to `backend/.env` and fill in values
+- Frontend: copy `frontend/.env.example` to `frontend/.env` and fill in values
+- Docker: `docker-compose up` to start all services
+
+## Key Patterns
+
+- API endpoints live in `backend/otodb/api/` as Django Ninja routers
+- SvelteKit routes in `frontend/src/routes/`
+- Reusable components in `frontend/src/lib/`
+- Never skip pre-commit hooks (`--no-verify`)
+- When modifying the backend API, regenerate frontend types: `bunx openapi-typescript <url> -o src/lib/api/schema.d.ts`


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project overview, architecture, development commands, code style, testing, and key patterns for Claude Code
- Add `.github/copilot-instructions.md` with equivalent guidance for GitHub Copilot

## Test plan

- [ ] Verify `CLAUDE.md` is picked up by Claude Code in this repo
- [ ] Verify `.github/copilot-instructions.md` is recognized by GitHub Copilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)