### PR TITLE
Better markdown table rendering

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/typography';
+@config '../tailwind.config.js';
 @import './themes.css';
 
 @theme inline {
@@ -160,8 +161,4 @@
 		padding-left: 0.5rem;
 		margin-left: -0.5rem;
 	}
-}
-
-.prose table {
-	width: fit-content;
 }

--- a/frontend/src/routes/tag/[tag_slug]/+page.svelte
+++ b/frontend/src/routes/tag/[tag_slug]/+page.svelte
@@ -184,7 +184,7 @@
 		</div>
 		{#if wp}
 			<div
-				class="prose prose-neutral prose-sm dark:prose-invert max-w-none [&_:is(p,ul,ol,blockquote,h1,h2,h3,h4,h5,h6)]:max-w-4xl"
+				class="prose prose-neutral prose-sm dark:prose-invert prose-p:max-w-4xl prose-ul:max-w-4xl prose-ol:max-w-4xl prose-blockquote:max-w-4xl prose-headings:max-w-4xl max-w-none"
 			>
 				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 				{@html renderMarkdown(wp.page)}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+	theme: {
+		extend: {
+			typography: {
+				DEFAULT: {
+					css: {
+						table: {
+							width: 'fit-content'
+						}
+					}
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
Updates tag wiki page prose to use full width (except for text elements), and globally modifies prose tables to only use the necessary width needed.

Will display tables more nicely like the one here: https://otodb.net/tag/favotomædiii