### PR TITLE
Add <details> styling

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -141,6 +141,44 @@
 		content: '*';
 		color: var(--otodb-color-del);
 	}
+
+	details {
+		background-color: color-mix(in hsl, transparent 40%, var(--otodb-color-bg-fainter));
+		padding: 0.5rem;
+		cursor: pointer;
+		user-select: none;
+		font-weight: bold;
+		margin: 0.5rem 0;
+
+		&:hover {
+			background-color: var(--otodb-color-bg-primary);
+		}
+
+		&[open] {
+			cursor: pointer;
+			user-select: auto;
+			background-color: var(--otodb-color-bg-faint);
+
+			&:hover {
+				background-color: var(--otodb-color-bg-faint);
+			}
+
+			> :not(summary) {
+				cursor: default;
+				font-weight: normal;
+			}
+		}
+
+		&[open] > summary {
+			cursor: pointer;
+			user-select: none;
+			margin-bottom: 0.5rem;
+
+			&:hover {
+				background-color: inherit;
+			}
+		}
+	}
 }
 
 /* Autolink headings */


### PR DESCRIPTION
<details><summary>Before</summary>
<p>

<img width="824" height="506" alt="image" src="https://github.com/user-attachments/assets/62d4c836-50d5-4744-8636-f198fed53f7b" />

</p>
</details> 

<details open><summary>After</summary>
<p>

<img width="827" height="558" alt="image" src="https://github.com/user-attachments/assets/ea1e6013-cb88-4787-91d8-96de822a6542" />

</p>
</details> 

---

CSS is a bit more complicated than it should be ideally to handle the edge case where details could be defined without a summary (such as in wiki pages) 