### PR TITLE
Update robots.txt

### DIFF
--- a/frontend/static/robots.txt
+++ b/frontend/static/robots.txt
@@ -4,22 +4,22 @@ Disallow: /
 
 Allow: /$
 
-Disallow: /api
-Disallow: /work/random
-Disallow: /work/add
-Disallow: /work/merge
-Disallow: /work/unbound
-Disallow: /work/tags_needed
-Disallow: /tag/alias
-Disallow: /list/new
-Disallow: /list/import
-Disallow: /post/new
-Disallow: /*edit
-Disallow: /*history
-Disallow: /*threads
-Disallow: /*notifications
-Disallow: /*submissions
-Disallow: /*delete
+Disallow: /*/add$
+Disallow: /*/new$
+Disallow: /*/import$
+Disallow: /*/edit$
+Disallow: /*/delete$
+Disallow: /*/alias$
+Disallow: /*/threads$
+Disallow: /*/notifications$
+Disallow: /*/submissions$
+Disallow: /*/revisions$
+Disallow: /*/random$
+
+Disallow: /profile/*/edit$
+Disallow: /song_attribute/*/edit$
+Disallow: /song_attribute/*/history$
+Disallow: /song_attribute/alias$
 
 # SvelteKit build assets
 Allow: /_app/
@@ -43,9 +43,29 @@ Allow: /song_attribute
 Allow: /list
 Allow: /profile
 Allow: /comments
+Allow: /register
+Allow: /login
+Allow: /settings
 Allow: /404
 Allow: /sitemap.xml
 
+# Special cases
+## API and other non-public endpoints
+Disallow: /api
+Disallow: /work/merge
+Disallow: /work/unbound
+Disallow: /work/tags_needed
+
+## Only allow main revision history page for discovery
+Disallow: /revision
+Disallow: /*/history$
+Allow: /revision/history$
+
+## Allow search pages but not search queries
+Allow: /*/search$
+Disallow: /*/search?
+
+# Sitemaps
 Sitemap: https://otodb.net/sitemap.xml?type=works
 Sitemap: https://otodb.net/sitemap.xml?type=tags
 Sitemap: https://otodb.net/sitemap.xml?type=song_attributes


### PR DESCRIPTION
Consolidates several endpoints, adds a few new endpoints, fixes wildcards, and handles some edge cases like search endpoints.

Endpoints like these would previously be allowed/disallowed, but this PR fixes those (the results below are **without** this PR, which is not the intended behavior):
```
ALLOW     /profile/mmaker/edit
ALLOW     /work/search?query=mowtendoo

# Not an actual tag currently, but substrings were being matched here
DISALLOW  /tag/unedited
```

Sanity tested manually with https://github.com/google/robotstxt to make sure endpoints are allowed/disallowed when applicable
