### PR TITLE
Improved frontend error handling

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -306,5 +306,8 @@
 	"free_tiny_badger_breathe": "edited {time} by ",
 	"agent_honest_marten_renew": "",
 	"plain_polite_eagle_build": "Last post",
-	"formal_ok_fly_buzz": "Bind to Existing Work"
+	"formal_ok_fly_buzz": "Bind to Existing Work",
+	"careful_gross_husky_grasp": "Error",
+	"key_pink_pigeon_treasure": "Oops!",
+	"ideal_soft_falcon_urge": "Something went wrong. Check the browser console for more info."
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -274,5 +274,8 @@
 	"same_only_emu_startle": "（{time}に編集）",
 	"free_tiny_badger_breathe": "{time}に",
 	"agent_honest_marten_renew": "が編集",
-	"plain_polite_eagle_build": "最新の投稿"
+	"plain_polite_eagle_build": "最新の投稿",
+	"careful_gross_husky_grasp": "エラー",
+	"key_pink_pigeon_treasure": "おっと！",
+	"ideal_soft_falcon_urge": "問題が発生しました。詳細はブラウザのコンソールをご確認ください。"
 }

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -274,5 +274,8 @@
 	"same_only_emu_startle": "({time} 수정됨)",
 	"free_tiny_badger_breathe": "{time} ",
 	"agent_honest_marten_renew": " 수정됨",
-	"plain_polite_eagle_build": "최근 게시물"
+	"plain_polite_eagle_build": "최근 게시물",
+	"careful_gross_husky_grasp": "오류",
+	"key_pink_pigeon_treasure": "이런!",
+	"ideal_soft_falcon_urge": "문제가 발생했습니다. 자세한 내용은 브라우저 콘솔을 확인해 주세요."
 }

--- a/frontend/messages/zh-cn.json
+++ b/frontend/messages/zh-cn.json
@@ -275,5 +275,8 @@
 	"same_only_emu_startle": "（{time}编辑）",
 	"free_tiny_badger_breathe": "{time}由",
 	"agent_honest_marten_renew": "编辑",
-	"plain_polite_eagle_build": "最新回复"
+	"plain_polite_eagle_build": "最新回复",
+	"careful_gross_husky_grasp": "错误",
+	"key_pink_pigeon_treasure": "哎呀！",
+	"ideal_soft_falcon_urge": "出了点问题。请查看浏览器控制台了解更多信息。"
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -8,10 +8,32 @@
 	import { LanguageNames, Themes, UserLevel } from '$lib/enums';
 	import ConnectionFavicon from '$lib/ConnectionFavicon.svelte';
 	import { getLocale, locales } from '$lib/paraglide/runtime';
-	import { beforeNavigate } from '$app/navigation';
+	import { afterNavigate, beforeNavigate } from '$app/navigation';
 	import { env } from '$env/dynamic/public';
+	import { callErrorToast } from '$lib/toast';
+	import Section from '$lib/Section.svelte';
 
 	let { data, children } = $props();
+
+	function handleError(e: Event) {
+		const err = e as ErrorEvent;
+		console.error(err.error ?? err.message);
+		callErrorToast(m.ideal_soft_falcon_urge());
+	}
+
+	function handleRejection(e: PromiseRejectionEvent) {
+		console.error(e.reason);
+		callErrorToast(m.ideal_soft_falcon_urge());
+	}
+
+	let boundaryError: unknown = $state(null);
+	let boundaryReset: () => void = $state(() => {});
+
+	function handleBoundaryError(e: unknown, reset: () => void) {
+		console.error(e);
+		boundaryError = e;
+		boundaryReset = reset;
+	}
 
 	let isMobileNavOpen = $state(false);
 	function toggleMobileNav() {
@@ -27,6 +49,12 @@
 			Array.from(document.querySelectorAll('form')).some(isFormDirty)
 		)
 			if (!confirm(m.raw_actual_mallard_exhale())) cancel();
+	});
+	afterNavigate(() => {
+		if (boundaryError) {
+			boundaryError = null;
+			boundaryReset();
+		}
 	});
 
 	let search_type = $state('work');
@@ -72,6 +100,8 @@
 			: null
 	);
 </script>
+
+<svelte:window onerror={handleError} onunhandledrejection={handleRejection} />
 
 <svelte:head>
 	{#if page.data.head?.title}
@@ -333,7 +363,21 @@
 		</div>
 		<div class="grow">
 			<main id="content">
-				{@render children()}
+				<svelte:boundary onerror={handleBoundaryError}>
+					{@render children()}
+					{#snippet failed()}
+						<Section title={m.careful_gross_husky_grasp()}>
+							<div
+								class="mx-[10%] my-1 border border-red-700 bg-red-950/50 p-4 text-left"
+							>
+								<h2 class="mb-1 text-lg font-bold">
+									{m.key_pink_pigeon_treasure()}
+								</h2>
+								<p>{m.ideal_soft_falcon_urge()}</p>
+							</div>
+						</Section>
+					{/snippet}
+				</svelte:boundary>
 			</main>
 			<footer>
 				<div class="footer-left">


### PR DESCRIPTION
Handles errors, promise rejections, and sets up [Svelte boundary](https://svelte.dev/docs/svelte/svelte-boundary).

Related to https://github.com/otoDB/otoDB/pull/467 as the page is entirely blocked from loading without this additional change.