### PR TITLE
Add null checks for API data in server load functions

### DIFF
--- a/frontend/src/routes/list/[list_id]/+page.server.ts
+++ b/frontend/src/routes/list/[list_id]/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch, params, url }) => {
@@ -24,5 +25,7 @@ export const load: PageServerLoad = async ({ fetch, params, url }) => {
 			params: { query: { list_id: +params.list_id, limit: batch_size, offset: 0 } }
 		})
 	]);
+	// TODO: properly handle fetch errors
+	if (!entries) error(500, 'Failed to fetch data.');
 	return { entries, comments, pending_items, batch_size, page };
 };

--- a/frontend/src/routes/list/[list_id]/edit/+page.server.ts
+++ b/frontend/src/routes/list/[list_id]/edit/+page.server.ts
@@ -1,4 +1,4 @@
-import { fail, redirect, type Actions } from '@sveltejs/kit';
+import { error, fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import client from '$lib/api';
 
@@ -17,6 +17,8 @@ export const load: PageServerLoad = async ({ params, parent }) => {
 			}
 		}
 	});
+	// TODO: properly handle fetch errors
+	if (!entries) error(500, 'Failed to fetch data.');
 	return { batch_size, entries };
 };
 

--- a/frontend/src/routes/post/[post_id]/+page.server.ts
+++ b/frontend/src/routes/post/[post_id]/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import { Languages } from '$lib/enums';
 import { get_entity, renderMarkdown } from '$lib/markdown';
 import { fail } from '@sveltejs/kit';
@@ -11,6 +12,8 @@ export const load: LayoutServerLoad = async ({ fetch, params }) => {
 		fetch,
 		params: { query: { model: 'post', pk: +params.post_id } }
 	});
+	// TODO: properly handle fetch errors
+	if (!comments) error(500, 'Failed to fetch data.');
 	return { comments };
 };
 

--- a/frontend/src/routes/profile/[username]/+page.server.ts
+++ b/frontend/src/routes/profile/[username]/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch, parent, params }) => {
@@ -18,6 +19,9 @@ export const load: PageServerLoad = async ({ fetch, parent, params }) => {
 			params: { query: { model: 'account', pk: data.profile.id } }
 		})
 	]);
+
+	// TODO: properly handle fetch errors
+	if (!comments) error(500, 'Failed to fetch data.');
 
 	return { comments, connections };
 };

--- a/frontend/src/routes/request/[id]/+page.server.ts
+++ b/frontend/src/routes/request/[id]/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import { m } from '$lib/paraglide/messages';
 import type { PageServerLoad } from './$types';
 
@@ -22,6 +23,10 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
 			}
 		})
 	]);
+
+	// TODO: properly handle fetch errors (e.g. 404 for not found)
+	if (!data) error(500, 'Failed to fetch data.');
+	if (!comments) error(500, 'Failed to fetch data.');
 
 	return {
 		request: data,

--- a/frontend/src/routes/revision/[id]/+page.server.ts
+++ b/frontend/src/routes/revision/[id]/+page.server.ts
@@ -24,6 +24,9 @@ export const load: PageServerLoad = async ({ params, fetch, url }) => {
 
 	if (!revision) error(404, { message: 'Not found' });
 
+	if (!changes) error(500, { message: 'Internal server error' });
+	if (!revision) error(500, { message: 'Internal server error' });
+
 	return {
 		revision,
 		changes,

--- a/frontend/src/routes/song_attribute/[tag_slug]/+page.server.ts
+++ b/frontend/src/routes/song_attribute/[tag_slug]/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, fetch, parent }) => {
@@ -18,6 +19,9 @@ export const load: PageServerLoad = async ({ params, fetch, parent }) => {
 			params: { query: { model: 'tagsong', pk: data.tag.id } }
 		})
 	]);
+
+	// TODO: properly handle fetch errors
+	if (!songs) error(500, 'Failed to fetch data.');
 
 	return {
 		songs,

--- a/frontend/src/routes/song_attribute/[tag_slug]/history/+page.server.ts
+++ b/frontend/src/routes/song_attribute/[tag_slug]/history/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
@@ -11,6 +12,9 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			}
 		}
 	});
+
+	// TODO: properly handle fetch errors
+	if (!history) error(500, 'Failed to fetch data.');
 
 	return {
 		history

--- a/frontend/src/routes/tag/[tag_slug]/+page.server.ts
+++ b/frontend/src/routes/tag/[tag_slug]/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, fetch, parent }) => {
@@ -39,6 +40,9 @@ export const load: PageServerLoad = async ({ params, fetch, parent }) => {
 				params: { query: { model: 'tagwork', pk: data.tag.id } }
 			})
 		]);
+
+	// TODO: properly handle fetch errors
+	if (!details) error(500, 'Failed to fetch data.');
 
 	const song_relations = data.song_relations;
 

--- a/frontend/src/routes/tag/[tag_slug]/edit/+page.server.ts
+++ b/frontend/src/routes/tag/[tag_slug]/edit/+page.server.ts
@@ -1,5 +1,5 @@
 import client from '$lib/api';
-import { fail, redirect, type Actions } from '@sveltejs/kit';
+import { error, fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { UserLevel } from '$lib/enums';
 import userLevelGuard from '$lib/route_guard';
@@ -33,6 +33,10 @@ export const load: PageServerLoad = async ({ params, fetch, locals, url, parent 
 			}
 		})
 	]);
+
+	// TODO: properly handle fetch errors
+	if (!details) error(500, 'Failed to fetch data.');
+	if (!connections) error(500, 'Failed to fetch data.');
 
 	const p = await parent();
 	// FIXME This is kind of waterfall but whatever...

--- a/frontend/src/routes/tag/[tag_slug]/threads/+page.server.ts
+++ b/frontend/src/routes/tag/[tag_slug]/threads/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, fetch, url }) => {
@@ -15,6 +16,8 @@ export const load: PageServerLoad = async ({ params, fetch, url }) => {
 			}
 		}
 	});
+	// TODO: properly handle fetch errors
+	if (!data) error(500, 'Failed to fetch data.');
 	return {
 		threads: data,
 		batch_size,

--- a/frontend/src/routes/work/[work_id]/threads/+page.server.ts
+++ b/frontend/src/routes/work/[work_id]/threads/+page.server.ts
@@ -1,4 +1,5 @@
 import client from '$lib/api';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, fetch, url }) => {
@@ -15,6 +16,9 @@ export const load: PageServerLoad = async ({ params, fetch, url }) => {
 			}
 		}
 	});
+
+	if (!data) error(500, 'Failed to fetch threads.');
+
 	return {
 		threads: data,
 		batch_size,


### PR DESCRIPTION
## Summary

- 12個の `+page.server.ts` ファイルに対して、API fetchの結果が `undefined` の場合に `error(500)` を投げるnullチェックを追加
- これにより、`load` 関数の返り値の型が `T | undefined` から `T` に絞り込まれ、下流の `.svelte` ファイルの型エラーを解消

## 対象ファイル

- `list/[list_id]/+page.server.ts`
- `list/[list_id]/edit/+page.server.ts`
- `post/[post_id]/+page.server.ts`
- `profile/[username]/+page.server.ts`
- `request/[id]/+page.server.ts`
- `revision/[id]/+page.server.ts`
- `song_attribute/[tag_slug]/+page.server.ts`
- `song_attribute/[tag_slug]/history/+page.server.ts`
- `tag/[tag_slug]/+page.server.ts`
- `tag/[tag_slug]/edit/+page.server.ts`
- `tag/[tag_slug]/threads/+page.server.ts`
- `work/[work_id]/threads/+page.server.ts`

## svelte-check 結果

| | errors | warnings |
|---|---|---|
| before (master) | 354 | 81 |
| after | **325** | 81 |
| **差分** | **-29** | 0 |

## Test plan

- [ ] `bun run check` で 325 errors / 81 warnings を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)