### PR TITLE
fix(frontend): Pass internal secret via `params.header` instead of `headers`

### DIFF
--- a/frontend/src/routes/comments/+page.server.ts
+++ b/frontend/src/routes/comments/+page.server.ts
@@ -26,7 +26,7 @@ export const actions = {
 		if (renderMarkdown(comment_text).trim() === '') return fail(400);
 		await client.POST('/api/comment/comment', {
 			fetch,
-			headers: { 'otodb-internal-secret': env.OTODB_INTERNAL_API_SECRET },
+			params: { header: { 'otodb-internal-secret': env.OTODB_INTERNAL_API_SECRET } },
 			body: {
 				model,
 				pk,
@@ -43,7 +43,7 @@ export const actions = {
 		if (renderMarkdown(comment_text).trim() === '') return fail(400);
 		await client.PUT('/api/comment/comment', {
 			fetch,
-			headers: { 'otodb-internal-secret': env.OTODB_INTERNAL_API_SECRET },
+			params: { header: { 'otodb-internal-secret': env.OTODB_INTERNAL_API_SECRET } },
 			body: { comment_id, comment_text }
 		});
 	}

--- a/frontend/src/routes/post/[post_id]/+page.server.ts
+++ b/frontend/src/routes/post/[post_id]/+page.server.ts
@@ -29,7 +29,7 @@ export const actions = {
 		if (renderMarkdown(post).trim() === '') return fail(400);
 		await client.PUT('/api/post/post', {
 			fetch,
-			headers: { 'otodb-internal-secret': env.OTODB_INTERNAL_API_SECRET },
+			params: { header: { 'otodb-internal-secret': env.OTODB_INTERNAL_API_SECRET } },
 			body: {
 				post_id: +params.post_id,
 				title,

--- a/frontend/src/routes/post/new/+page.server.ts
+++ b/frontend/src/routes/post/new/+page.server.ts
@@ -30,7 +30,7 @@ export const actions = {
 		if (renderMarkdown(post).trim() === '') return fail(400);
 		const { data: r, error } = await client.POST('/api/post/post', {
 			fetch,
-			headers: { 'otodb-internal-secret': env.OTODB_INTERNAL_API_SECRET },
+			params: { header: { 'otodb-internal-secret': env.OTODB_INTERNAL_API_SECRET } },
 			body: {
 				category: +category,
 				post,


### PR DESCRIPTION
## Summary

- `openapi-fetch` では、スキーマ定義済みのヘッダーは `headers: { ... }` ではなく `params: { header: { ... } }` で渡す必要がある（少なくともそちらのほうが型情報を利用できる．）
- 以下4箇所を修正:
  - `comments/+page.server.ts` — `POST /api/comment/comment`（create）
  - `comments/+page.server.ts` — `PUT /api/comment/comment`（edit）
  - `post/[post_id]/+page.server.ts` — `PUT /api/post/post`（edit）
  - `post/new/+page.server.ts` — `POST /api/post/post`（new）

## Test plan

- [ ] `bun run check` で `otodb-internal-secret` 関連の型エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)