### PR TITLE
Niconico specific description sanitization

### DIFF
--- a/backend/otodb/common.py
+++ b/backend/otodb/common.py
@@ -28,6 +28,24 @@ from .models.enums import Platform, MimeType
 
 logger = logging.getLogger(__name__)
 
+# https://qa.nicovideo.jp/faq/show/821
+# https://qa.nicovideo.jp/faq/show/822
+# Older Niconico uploads used <font> instead of <span style="...">
+# and <b> instead of <strong>
+ALLOWED_TAGS = {'a', 'b', 'br', 'font', 'strong', 'i', 's', 'u', 'span'}
+ALLOWED_ATTRIBUTES = {'a': {'href'}, 'font': {'color', 'size'}, 'span': {'style'}}
+ALLOWED_STYLE_PROPERTIES = {'color', 'font-size'}
+
+
+def clean_description(text: str) -> str:
+	"""Sanitize video HTML description using `nh3`"""
+	return nh3.clean(
+		text,
+		tags=ALLOWED_TAGS,
+		attributes=ALLOWED_ATTRIBUTES,
+		filter_style_properties=ALLOWED_STYLE_PROPERTIES,
+	)
+
 
 def NFKC(s: str):
 	return unicodedata.normalize('NFKC', s)
@@ -275,7 +293,7 @@ def process_video_info(full_info, link=None):
 			info['tags'] = list(dict.fromkeys(info['tags']))
 
 		# Clean description
-		info['description'] = nh3.clean(info['description'])
+		info['description'] = clean_description(info['description'])
 
 		# Get thumbnail mime type
 		info['thumbnail_mime'] = fetch_thumbnail_mime_type(info['thumbnail'])

--- a/backend/otodb/models/media.py
+++ b/backend/otodb/models/media.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING, cast
 
-import nh3
-
 from django.db import models
 from django.db.models import Prefetch
 from django.urls import reverse
@@ -11,6 +9,7 @@ from tagulous.models import TagField, TaggedManager
 from .enums import Rating, WorkTagCategory, Role
 from .tag import TagWork, TagSong, tagwork_ordering_case
 from .revision import RevisionTrackedModel
+from otodb.common import clean_description
 
 if TYPE_CHECKING:
 	from django.db.models import QuerySet
@@ -211,7 +210,7 @@ class MediaWork(RevisionTrackedModel):
 
 	def save(self, *args, **kwargs):
 		if self.description:
-			self.description = nh3.clean(self.description)
+			self.description = clean_description(self.description)
 		super().save(*args, **kwargs)
 
 	@cached_property


### PR DESCRIPTION
Closes https://github.com/otoDB/otoDB/issues/501

Will fix in production with the following script:

<details><summary>Details</summary>
<p>

```python
from django.core.management.base import BaseCommand
from django.db.models import Q

from otodb.common import clean_description
from otodb.models.media import MediaWork
from otodb.models.work_source import WorkSource
from otodb.models.enums import Platform


class Command(BaseCommand):
	def add_arguments(self, parser):
		parser.add_argument(
			'--dry-run',
			action='store_true',
			help='Show what would be changed without writing to the database',
		)

	def handle(self, *args, **options):
		dry_run = options['dry_run']

		if dry_run:
			self.stdout.write(
				self.style.WARNING('DRY RUN MODE - No changes will be made')
			)

		# Simple filter for sources whose current description contains HTML
		html_filter = (
			Q(description__contains='<a ')
			| Q(description__contains='<br')
			| Q(description__contains='<font')
			| Q(description__contains='<strong')
			| Q(description__contains='<i>')
			| Q(description__contains='<i ')
			| Q(description__contains='<s>')
			| Q(description__contains='<s ')
			| Q(description__contains='<u>')
			| Q(description__contains='<u ')
			| Q(description__contains='<span')
		)

		sources = (
			WorkSource.objects.filter(
				platform=Platform.NICONICO,
				description__isnull=False,
				info_payload__isnull=False,
			)
			.filter(html_filter)
			.select_related('info_payload', 'media')
		)

		total = sources.count()
		self.stdout.write(f'Found {total} Niconico source(s) with HTML in descriptions')

		sources_updated = 0
		works_updated = 0
		skipped = 0

		for source in sources.iterator():
			# Re-extract the original description from the cached API payload
			# and re-sanitize it with the updated whitelist
			raw_description = source.info_payload.payload['video']['description']
			new_description = clean_description(raw_description)

			if new_description == source.description:
				skipped += 1
				continue

			# Update the source description
			sources_updated += 1
			old_description = source.description
			self.stdout.write(f'  Source {source.pk} ({source.url}):')
			self.stdout.write(f'    Old: {old_description[:120]}...')
			self.stdout.write(f'    New: {new_description[:120]}...')

			if not dry_run:
				source.description = new_description
				source.save(update_fields=['description'])

			# Update the parent work's description, but only if it
			# currently matches this source's old description (meaning the work
			# is still using the source description and hasn't been manually edited).
			work = source.media
			if (
				work
				and work.moved_to_id is None
				and work.description == old_description
			):
				works_updated += 1
				self.stdout.write(f'    -> Also updating Work {work.pk}: {work.title}')

				if not dry_run:
					MediaWork.objects.filter(pk=work.pk).update(
						description=new_description
					)

		self.stdout.write('')
		verb = 'Would update' if dry_run else 'Updated'
		self.stdout.write(
			self.style.SUCCESS(
				f'{verb} {sources_updated} source(s) and {works_updated} work(s), '
				f'skipped {skipped} (no change)'
			)
		)

		if dry_run and sources_updated:
			self.stdout.write('')
			self.stdout.write(
				self.style.WARNING('This was a dry run - no changes were made')
			)

```

</p>
</details> 