### PR TITLE
Support nicovideo.jp/shorts/ URLs

### DIFF
--- a/backend/otodb/common.py
+++ b/backend/otodb/common.py
@@ -64,8 +64,8 @@ def slugify_tag(s: str):
 
 
 class NiconicoIECustom(NiconicoIE):
-	# Support nico.ms short URLs
-	_VALID_URL = r'https?://(?:(?:embed|sp|www\.)?nicovideo\.jp/watch|nico\.ms)/(?P<id>(?:[a-z]{2})?\d+)'
+	# Support nico.ms short URLs and /shorts/ URLs
+	_VALID_URL = r'https?://(?:(?:embed|sp|www\.)?nicovideo\.jp/(?:watch|shorts)|nico\.ms)/(?P<id>(?:[a-z]{2})?\d+)'
 
 
 ydl_playlist = YoutubeDL(


### PR DESCRIPTION
Updates an internal yt-dlp regex, similar to what we did to support shortened URLs in the nico.ms form. All Niconico Shorts redirect to the normal watch page so this should be all that is needed.

Example: https://www.nicovideo.jp/shorts/ss46170386 (redirects to https://www.nicovideo.jp/watch/ss46170386)