### PR TITLE
Refactor handling `PostCategory` in `/post/new/page`

### DIFF
--- a/frontend/src/routes/post/new/+page.server.ts
+++ b/frontend/src/routes/post/new/+page.server.ts
@@ -3,14 +3,17 @@ import client from '$lib/api';
 import { get_entity, parseMentions, renderMarkdown } from '$lib/markdown';
 import { m } from '$lib/paraglide/messages';
 import { userLevelGuard } from '$lib/route_guard';
-import { Levels, type components } from '$lib/schema';
+import { Levels, PostCategory, type components } from '$lib/schema';
+import { enumValues } from '$lib/enums';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getLanguageId, languages } from '$lib/enums/language';
 
 export const load: PageServerLoad = ({ locals, url }) => {
 	userLevelGuard(locals.user, Levels.Member);
-	const category = url.searchParams.get('category');
+	const paramCategory = parseInt(url.searchParams.get('category') as string, 10);
+	const category: PostCategory | null =
+		paramCategory && (enumValues(PostCategory).includes(paramCategory) ? paramCategory : null);
 	const entity = url.searchParams.get('entity');
 	return { category, entity, head: { title: m.antsy_aloof_horse_grace() } };
 };

--- a/frontend/src/routes/post/new/+page.svelte
+++ b/frontend/src/routes/post/new/+page.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import Section from '$lib/Section.svelte';
-
-	let { data } = $props();
-	import { m } from '$lib/paraglide/messages.js';
 	import { buildEntityRoutes, enumValues } from '$lib/enums';
 	import { languages } from '$lib/enums/language.js';
-	import { getLocale, locales } from '$lib/paraglide/runtime';
-	import { get_entity, renderMarkdown } from '$lib/markdown';
-	import { PostCategory } from '$lib/schema.js';
 	import { postCategoryNames } from '$lib/enums/postCategory.js';
+	import { get_entity, renderMarkdown } from '$lib/markdown';
+	import { m } from '$lib/paraglide/messages.js';
+	import { getLocale, locales } from '$lib/paraglide/runtime';
+	import { PostCategory } from '$lib/schema.js';
 
+	let { data } = $props();
 	let md = $state('');
 	let previewHtml = $derived(renderMarkdown(md));
-	let category = $derived(data.category ?? '1');
+	let category: PostCategory = $derived(data.category ?? PostCategory.Bug_Report);
 	let entities_raw = $derived(data.entity ?? '');
 	let entities = $derived(
 		entities_raw
@@ -43,7 +42,7 @@
 					><th>{m.plane_awful_bobcat_spark()}</th><td
 						><select name="category" bind:value={category}>
 							{#each enumValues(PostCategory) as c, i (i)}
-								{#if i > 0}
+								{#if c !== PostCategory.Announcement}
 									<option value={c}>{postCategoryNames[c]()}</option>
 								{/if}
 							{/each}
@@ -52,7 +51,7 @@
 				></tbody
 			>
 		</table>
-		{#if category === '3'}
+		{#if category === PostCategory.Gardening}
 			<h4>{m.fine_zany_octopus_trim()}</h4>
 			<textarea name="entities" bind:value={entities_raw}></textarea>
 			<ul class="inline-block">


### PR DESCRIPTION
## Summary

- Replace magic string/number literals with `PostCategory` enum values in `/post/new`
- Type `category` as `PostCategory` instead of `string`
- Use `PostCategory.Announcement` instead of index check, `PostCategory.Gardening` instead of `'3'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)