### PR TITLE
Fix inverted PostCategory filter logic in /post search

### DIFF
--- a/frontend/src/routes/post/+page.server.ts
+++ b/frontend/src/routes/post/+page.server.ts
@@ -12,7 +12,7 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 
 	const paramCategory = parseInt(url.searchParams.get('category') as string, 10);
 	const category: PostCategory | null =
-		paramCategory && !enumValues(PostCategory).includes(paramCategory) ? paramCategory : null;
+		paramCategory && (enumValues(PostCategory).includes(paramCategory) ? paramCategory : null);
 
 	const { data } = await client.GET('/api/post/search', {
 		fetch,


### PR DESCRIPTION
## Summary

- `!enumValues(PostCategory).includes(paramCategory)` was returning the category when it was **not** in the enum, which is backwards
- Fixed to `enumValues(PostCategory).includes(paramCategory) ? paramCategory : null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)