### PR TITLE
Fix to_active methods on RevisionMeta

### DIFF
--- a/backend/otodb/models/media.py
+++ b/backend/otodb/models/media.py
@@ -182,7 +182,8 @@ class MediaWork(RevisionTrackedModel):
 		tracked_fields = ['title', 'description', 'rating', 'moved_to']
 		entity_attrs = ['self', 'moved_to']
 
-		def to_active(self, instance: 'MediaWork') -> 'MediaWork':
+		@staticmethod
+		def to_active(instance: 'MediaWork') -> 'MediaWork':
 			return instance.moved_to or instance
 
 	# deprecated!

--- a/backend/otodb/models/tag.py
+++ b/backend/otodb/models/tag.py
@@ -246,7 +246,8 @@ class TagWork(RevisionTrackedModel, OtodbTagModel):
 		]
 		entity_attrs = ['self', 'aliased_to']
 
-		def to_active(self, instance: 'TagWork') -> 'TagWork':
+		@staticmethod
+		def to_active(instance: 'TagWork') -> 'TagWork':
 			return instance.aliased_to or instance
 
 	def __str__(self):
@@ -555,6 +556,7 @@ class TagSong(RevisionTrackedModel, OtodbTagModel):
 		tracked_fields = ['name', 'slug', 'aliased_to', 'category', 'parent']
 		entity_attrs = ['self']
 
+		@staticmethod
 		def to_active(instance):
 			return instance.aliased_to or instance
 


### PR DESCRIPTION
Crashes with `TypeError: TagWork.RevisionMeta.to_active() missing 1 required positional argument: 'instance'` otherwise