### PR TITLE
Required field frontend fixes

### DIFF
--- a/frontend/src/routes/upload/[source_id]/+page.svelte
+++ b/frontend/src/routes/upload/[source_id]/+page.svelte
@@ -223,13 +223,13 @@
 							</td>
 						</tr>
 						<tr>
-							<th>{m.good_dark_bumblebee_spur()}</th>
+							<th><label>{m.good_dark_bumblebee_spur()}</label></th>
 							<td>
 								<div class="flex gap-2">
 									{#each enumValues(Rating) as r, i (i)}
 										<label
 											class={[
-												'cursor-pointer border px-3 py-1',
+												'relative cursor-pointer border px-3 py-1',
 												rating === r &&
 													'bg-otodb-content-primary text-otodb-bg-primary'
 											]}
@@ -239,7 +239,7 @@
 												name="rating"
 												value={r}
 												bind:group={rating}
-												class="hidden"
+												class="absolute inset-0 cursor-pointer opacity-0"
 												required
 											/>
 											{RatingNames[r]()}

--- a/frontend/src/routes/upload/add/+page.svelte
+++ b/frontend/src/routes/upload/add/+page.svelte
@@ -56,7 +56,7 @@
 					</tr>
 					<tr>
 						<th class="w-min whitespace-nowrap">
-							{m.watery_fuzzy_fireant_thrive()}
+							<label>{m.watery_fuzzy_fireant_thrive()}</label>
 						</th>
 						<td class="flex w-full gap-4">
 							<label>


### PR DESCRIPTION
Fixes the native browser tooltip for missing required fields which was broken since radio buttons were hidden (resulted in `The invalid form control with name=‘rating’ is not focusable.` being printed to the console and no visual feedback otherwise). Also adds the * label to the required radio button field field for new uploads.