### PR TITLE
Fix tag history

### DIFF
--- a/backend/otodb/api/history.py
+++ b/backend/otodb/api/history.py
@@ -707,13 +707,13 @@ def history(request: HttpRequest, entity: Query[HistoricalEntitySchema]):
 			query_ids = query_ids + [*merged.values_list('id', flat=True)]
 
 		case 'tagwork':
-			tag = TagWork.objects.get(slug=entity.id)
+			tag = TagWork.objects.get(id=entity.id)
 			if tag.aliased_to:
 				tag = tag.aliased_to
 			entity.id = tag.pk
 			query_ids = query_ids + [*tag.aliases.values_list('id', flat=True)]
 		case 'tagsong':
-			tag = TagSong.objects.get(slug=entity.id)
+			tag = TagSong.objects.get(id=entity.id)
 			if tag.aliased_to:
 				tag = tag.aliased_to
 			entity.id = tag.pk

--- a/frontend/src/routes/song_attribute/[tag_slug]/history/+page.server.ts
+++ b/frontend/src/routes/song_attribute/[tag_slug]/history/+page.server.ts
@@ -2,13 +2,15 @@ import client from '$lib/api.server';
 import { HistoricalEntities } from '$lib/schema';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params, fetch }) => {
+export const load: PageServerLoad = async ({ fetch, parent }) => {
+	const { tag } = await parent();
+
 	const { data: history } = await client.GET('/api/history/history', {
 		fetch,
 		params: {
 			query: {
 				entity: HistoricalEntities.tagsong,
-				id: params.tag_slug
+				id: tag.id
 			}
 		}
 	});

--- a/frontend/src/routes/tag/[tag_slug]/history/+page.server.ts
+++ b/frontend/src/routes/tag/[tag_slug]/history/+page.server.ts
@@ -10,7 +10,7 @@ export const load: PageServerLoad = async ({ params, fetch, parent }) => {
 		params: {
 			query: {
 				entity: HistoricalEntities.tagwork,
-				id: params.tag_slug
+				id: tag.id
 			}
 		}
 	});


### PR DESCRIPTION
Caused by regression in https://github.com/otoDB/otoDB/pull/647

We previously were querying history by using the tag slug in the ID param.