### PR TITLE
Document PR issue-linking convention in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,7 @@
 
 - This project does **not** follow Conventional Commits.
 - Write commit messages in plain, descriptive English that clearly explains what changed and why.
+
+## Pull request conventions
+
+- When creating a PR that is clearly related to a specific issue — either from the branch name (e.g. `SnO2WMaN/issue693`) or other context — always include a closing keyword like `close #693` in the PR body so that the issue is automatically closed when the PR is merged.


### PR DESCRIPTION
## Summary

- Adds a "Pull request conventions" section to AGENTS.md
- Instructs Claude and other agents to include closing keywords (e.g. `close #693`) in PRs when the work is clearly tied to a specific issue, so the issue is automatically closed on merge

## Test plan

- [ ] Verify AGENTS.md renders correctly
- [ ] Confirm future PRs from issue-related branches include closing keywords