### PR TITLE
Use raw API client to suppress errors in some cases

### DIFF
--- a/frontend/src/lib/TagEditTable.svelte
+++ b/frontend/src/lib/TagEditTable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import WorkTag from '$lib/WorkTag.svelte';
-	import client from '$lib/api';
+	import { rawClient } from '$lib/api';
 	import { allCreatorRoles, creatorRole } from '$lib/enums/creatorRole';
 	import { WorkTagCategoryMap } from '$lib/enums/workTagCategory';
 	import { m } from '$lib/paraglide/messages.js';
@@ -22,11 +22,11 @@
 		void tags;
 		const timeout = setTimeout(() => {
 			tags.filter((t) => !Object.hasOwn(cache, t)).forEach(async (t) => {
-				let { data } = await client.GET('/api/tag/tag', {
+				let { data } = await rawClient.GET('/api/tag/tag', {
 					params: { query: { tag_slug: t } }
 				});
 				if (data?.aliased_to) {
-					({ data } = await client.GET('/api/tag/tag', {
+					({ data } = await rawClient.GET('/api/tag/tag', {
 						params: { query: { tag_slug: data.aliased_to.slug } }
 					}));
 				}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,4 +17,8 @@ client.use({
 		return response;
 	}
 });
+export const rawClient = createClient<paths>({
+	baseUrl: env.PUBLIC_API_ENDPOINT,
+	credentials: 'include'
+});
 export default client;


### PR DESCRIPTION
Follow-up to https://github.com/otoDB/otoDB/pull/686

Inserting new tags into the tag edit table was causing 404s and thus an error toast to pop up -- that toast shouldn't be appearing in this scenario