### PR TITLE
Clearer message when aliasing tags with instances

### DIFF
--- a/backend/otodb/api/tag.py
+++ b/backend/otodb/api/tag.py
@@ -366,7 +366,11 @@ def alias_tags(
 	# Prevent users below editor from merging if any `from_tag` has instances
 	effective_from_tags = [t for t in tags if (t.aliased_to_id or t.pk) != into.pk]
 	if not request.user.is_editor and model.any_have_instances(effective_from_tags):
-		raise ApiError(403, ErrorCode.TAG_WITH_INSTANCES_MERGE_REQUIRES_EDITOR)
+		raise ApiError(
+			403,
+			ErrorCode.TAG_WITH_INSTANCES_MERGE_REQUIRES_EDITOR,
+			data={'into_tag': into.slug},
+		)
 
 	model.alias(tags, into)
 	if delete:

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -394,5 +394,5 @@
 	"bright_calm_finch_match": "Super Mario or Kirby works with mid-tempo songs",
 	"crisp_neat_wren_match": "Works tagged with Touhou or any child descendants, excluding any song tags under Touhou",
 	"swift_keen_otter_guide": "View docs",
-	"witty_brisk_hawk_merge": "At least one of these tags is associated to a work or song. Only editors can merge these tags."
+	"witty_brisk_hawk_merge": "At least one of the tags being merged into \"{into_tag}\" is associated to a work or song. Only editors can merge such tags."
 }

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -30,7 +30,7 @@ const errorCodeMessages: Partial<Record<ErrorCode, (payload: ErrorPayload) => st
 	[ErrorCode.Appeal_Pending]: () => m.calm_brisk_swan_queue(),
 	[ErrorCode.Tag_Has_Information]: () => m.that_new_mayfly_spur(),
 	[ErrorCode.Thumbnail_Source_Required]: () => m.sleek_brave_heron_choose(),
-	[ErrorCode.Tag_With_Instances_Merge_Requires_Editor]: (payload) => 
+	[ErrorCode.Tag_With_Instances_Merge_Requires_Editor]: (payload) =>
 		typeof payload.into_tag === 'string'
 			? m.witty_brisk_hawk_merge({ into_tag: payload.into_tag })
 			: null,

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -30,7 +30,10 @@ const errorCodeMessages: Partial<Record<ErrorCode, (payload: ErrorPayload) => st
 	[ErrorCode.Appeal_Pending]: () => m.calm_brisk_swan_queue(),
 	[ErrorCode.Tag_Has_Information]: () => m.that_new_mayfly_spur(),
 	[ErrorCode.Thumbnail_Source_Required]: () => m.sleek_brave_heron_choose(),
-	[ErrorCode.Tag_With_Instances_Merge_Requires_Editor]: () => m.witty_brisk_hawk_merge(),
+	[ErrorCode.Tag_With_Instances_Merge_Requires_Editor]: (payload) => 
+		typeof payload.into_tag === 'string'
+			? m.witty_brisk_hawk_merge({ into_tag: payload.into_tag })
+			: null,
 	[ErrorCode.Name_Slug_Mismatch]: (payload) =>
 		typeof payload.name === 'string' &&
 		typeof payload.slug === 'string' &&


### PR DESCRIPTION
I think this is better. Previous message didn't convey precisely what is checked on the backend.