### PR TITLE
Include direct parents in suggested tags

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2881,6 +2881,38 @@
           },
           {
             "in": "query",
+            "name": "min_parents",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Min Parents"
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "max_parents",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Max Parents"
+            },
+            "required": false
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "default": 30,

--- a/backend/otodb/api/source.py
+++ b/backend/otodb/api/source.py
@@ -17,7 +17,6 @@ from otodb.models import (
 	ModerationEvent,
 	TagWork,
 	TagWorkCreatorConnection,
-	TagWorkParenthood,
 	WorkSource,
 )
 from otodb.models.enums import (
@@ -253,17 +252,18 @@ def extract_source_tag_suggestions(src: WorkSource):
 	existing_slugs = {t.slug for t in matched}
 	resolved = {(t.aliased_to or t).pk: (t.aliased_to or t) for t in matched}
 
-	# Include direct parents of tags resolved from source
-	parent_ids = {
-		parent_id
-		for parent_id in TagWorkParenthood.objects.filter(
-			tag_id__in=resolved.keys(),
-			parent__deprecated=False,
-			parent__aliased_to__isnull=True,
-		).values_list('parent_id', flat=True)
-	}
-	active_resolved_tag_ids = {pk for pk, t in resolved.items() if not t.deprecated}
-	existing = list(TagWork.objects.filter(pk__in=active_resolved_tag_ids | parent_ids))
+	# Active resolved tags, plus direct parents
+	# (non-deprecated, non-aliased) of any resolved tag
+	existing = list(
+		TagWork.objects.filter(
+			Q(pk__in=[pk for pk, t in resolved.items() if not t.deprecated])
+			| Q(
+				deprecated=False,
+				aliased_to__isnull=True,
+				parenthood__tag_id__in=resolved.keys(),
+			)
+		).distinct()
+	)
 
 	new_tags = [
 		TagWorkSchema(

--- a/backend/otodb/api/source.py
+++ b/backend/otodb/api/source.py
@@ -17,6 +17,7 @@ from otodb.models import (
 	ModerationEvent,
 	TagWork,
 	TagWorkCreatorConnection,
+	TagWorkParenthood,
 	WorkSource,
 )
 from otodb.models.enums import (
@@ -251,11 +252,19 @@ def extract_source_tag_suggestions(src: WorkSource):
 	matched = TagWork.objects.filter(slug__in=slug_to_name.keys())
 	existing_slugs = {t.slug for t in matched}
 	resolved = {(t.aliased_to or t).pk: (t.aliased_to or t) for t in matched}
-	existing = list(
-		TagWork.objects.filter(pk__in=resolved.keys(), deprecated=False)
-		if resolved
-		else []
-	)
+
+	# Include direct parents of tags resolved from source
+	parent_ids = {
+		parent_id
+		for parent_id in TagWorkParenthood.objects.filter(
+			tag_id__in=resolved.keys(),
+			parent__deprecated=False,
+			parent__aliased_to__isnull=True,
+		).values_list('parent_id', flat=True)
+	}
+	active_resolved_tag_ids = {pk for pk, t in resolved.items() if not t.deprecated}
+	existing = list(TagWork.objects.filter(pk__in=active_resolved_tag_ids | parent_ids))
+
 	new_tags = [
 		TagWorkSchema(
 			id=0,

--- a/backend/otodb/api/tag.py
+++ b/backend/otodb/api/tag.py
@@ -9,6 +9,7 @@ import lark
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Case, Count, Exists, F, OuterRef, Q, Subquery, Value, When
+from django.db.models.functions import Coalesce
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Field, ModelSchema, Query, Schema
@@ -166,6 +167,8 @@ def search(
 	lang_pref: list[int] | None = Query(None),
 	lang_pref_missing: list[int] | None = Query(None),
 	has_connections: bool | None = None,
+	min_parents: int | None = None,
+	max_parents: int | None = None,
 ):
 	cleaned_slug_query = canonicalize_tag(query)
 	cleaned_name_query = NFKC(query)
@@ -184,6 +187,15 @@ def search(
 			qs = filter_tags_by_media_type(qs, media_type)
 
 	qs = qs.filter(deprecated=deprecated_only)
+	parent_count_sub = (
+		TagWorkParenthood.objects.filter(
+			tag_id=Coalesce(OuterRef('aliased_to_id'), OuterRef('pk'))
+		)
+		.order_by()
+		.values('tag_id')
+		.annotate(c=Count('*'))
+		.values('c')
+	)
 	qs = qs.annotate(
 		n_instance=Case(
 			When(aliased_to__isnull=False, then=Count('aliased_to__tagworkinstance')),
@@ -193,6 +205,9 @@ def search(
 		_has_connections=Exists(TagWorkConnection.objects.filter(tag=OuterRef('pk')))
 		| Exists(TagWorkMediaConnection.objects.filter(tag=OuterRef('pk')))
 		| Exists(TagWorkCreatorConnection.objects.filter(tag=OuterRef('pk'))),
+		n_parents=Coalesce(
+			Subquery(parent_count_sub, output_field=models.IntegerField()), 0
+		),
 	)
 
 	if hide_orphans:
@@ -227,6 +242,11 @@ def search(
 
 	if has_connections is not None:
 		qs = qs.filter(_has_connections=has_connections)
+
+	if min_parents is not None:
+		qs = qs.filter(n_parents__gte=min_parents)
+	if max_parents is not None:
+		qs = qs.filter(n_parents__lte=max_parents)
 
 	order_field = {
 		'newest': '-id',

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -299,7 +299,7 @@
 	"mellow_alert_jan_leap": "Unassigned",
 	"stout_same_insect_conquer": "Has connections",
 	"green_icy_earthworm_love": "Minimum parents",
-	"tangy_spry_bumblebee_transform": "Max parents",
+	"tangy_spry_bumblebee_transform": "Maximum parents",
 	"fine_zany_octopus_trim": "Linked entities",
 	"big_tiny_kitten_devour": "Threads",
 	"last_late_penguin_bubble": "Save",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -298,6 +298,8 @@
 	"strong_lower_firefox_exhale": "Missing display language",
 	"mellow_alert_jan_leap": "Unassigned",
 	"stout_same_insect_conquer": "Has connections",
+	"green_icy_earthworm_love": "Minimum parents",
+	"tangy_spry_bumblebee_transform": "Max parents",
 	"fine_zany_octopus_trim": "Linked entities",
 	"big_tiny_kitten_devour": "Threads",
 	"last_late_penguin_bubble": "Save",

--- a/frontend/src/routes/tag/+page.server.ts
+++ b/frontend/src/routes/tag/+page.server.ts
@@ -23,6 +23,10 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 		(s) => +s
 	);
 	const has_connections = url.searchParams.get('has_connections');
+	const min_parents_raw = url.searchParams.get('min_parents');
+	const min_parents = min_parents_raw ? parseInt(min_parents_raw, 10) : undefined;
+	const max_parents_raw = url.searchParams.get('max_parents');
+	const max_parents = max_parents_raw ? parseInt(max_parents_raw, 10) : undefined;
 	const page = parseInt(url.searchParams.get('page') ?? '1', 10) || 1;
 
 	const { data } = await client.GET('/api/tag/search', {
@@ -41,7 +45,9 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 				wiki_lang_missing,
 				lang_pref,
 				lang_pref_missing,
-				has_connections: has_connections ? has_connections === 'true' : undefined
+				has_connections: has_connections ? has_connections === 'true' : undefined,
+				min_parents,
+				max_parents
 			}
 		}
 	});
@@ -60,6 +66,8 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 		lang_pref,
 		lang_pref_missing,
 		has_connections,
+		min_parents,
+		max_parents,
 		page,
 		head: {
 			title: m.mild_loud_shad_enchant({

--- a/frontend/src/routes/tag/+page.svelte
+++ b/frontend/src/routes/tag/+page.svelte
@@ -99,6 +99,26 @@
 					<option value="false">{m.great_lucky_goldfish_sail()}</option>
 				</select>
 			</label>
+			<label class="flex flex-col">
+				{m.green_icy_earthworm_love()}
+				<input
+					type="number"
+					name="min_parents"
+					min="0"
+					value={data.min_parents ?? ''}
+					class="w-20"
+				/>
+			</label>
+			<label class="flex flex-col">
+				{m.tangy_spry_bumblebee_transform()}
+				<input
+					type="number"
+					name="max_parents"
+					min="0"
+					value={data.max_parents ?? ''}
+					class="w-20"
+				/>
+			</label>
 			<label>
 				<input type="checkbox" name="deprecated_only" checked={data.deprecated_only} />
 				{m.pink_funny_platypus_aim()}

--- a/frontend/src/routes/tag/[tag_slug]/+page.svelte
+++ b/frontend/src/routes/tag/[tag_slug]/+page.svelte
@@ -75,6 +75,10 @@
 			}
 		});
 
+	const sortedChildTags = $derived(
+		[...data.tag.children].sort((a, b) => Number(a.deprecated) - Number(b.deprecated))
+	);
+
 	const paths = $derived.by(() => {
 		const get_paths = (node: string): components['schemas']['TagWorkSchema'][][] =>
 			Object.hasOwn(data.paths[1], node)
@@ -222,11 +226,11 @@
 	</Section>
 {/if}
 
-{#if data.tag.children.length}
+{#if sortedChildTags.length}
 	<Section title={m.weird_nimble_fireant_climb()}>
 		<div class="flex flex-wrap gap-3">
-			{#each data.tag.children as tag, i (i)}
-				<WorkTag {tag} />
+			{#each sortedChildTags as tag, i (i)}
+				<WorkTag {tag} fade={tag.deprecated} />
 			{/each}
 		</div>
 	</Section>


### PR DESCRIPTION
The primary intent of this change is so we can begin work to deprecate superfluous combination tags in a way that then guides the user in what tags to actually use. This relies on such combination tags having their parents set appropriately. This change in general helps expose some other tags that may be relevant to add to works too.

With this change, we would be expecting superfluous combination tags to be deprecated, have their relevant parent(s) assigned, and ideally have a short blurb written for their wiki page explaining the reason for deprecation and how to tag appropriately. This is because a user can simply search for works using the unique tags that these combination tags are made up of, as they provide no new information, other than coining a term for their combination. Deprecating rather than deleting or not indexing them in the DB also allows these to be preserved for historical purposes, both in terms of the DB and the history of the medium itself.

Some examples of superfluous combination tags:
https://otodb.net/tag/kiraractors_anteroom
https://otodb.net/tag/gachimon
https://otodb.net/tag/delt_aru_ne

Noting that we may want some combination tags to not be deprecated, such as https://otodb.net/tag/UDKロイド since this tag could be part of a work with many other vocal synth sources, which would otherwise have no way to be distinguished. This seems applicable to me any time the combination is actually used within the content of the work itself, rather than being inferred. This may still be on a case-by-case basis though.

---

This PR also makes some tweaks to the frontend, such as fading and sorting deprecated tags to the end of the child tags list, and adding a new min and max parents filter to tag search to facilitate discovering these.