### PR TITLE
Add i18n locale switcher to Storybook

### DIFF
--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,10 +1,28 @@
-import type { Preview } from '@storybook/sveltekit';
-import { initialize, mswLoader } from 'msw-storybook-addon';
-import '../src/app.css';
-import { setLocale } from '../src/lib/paraglide/runtime';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
+import type { Preview } from '@storybook/sveltekit';
+import { initialize as mswInitialize, mswLoader } from 'msw-storybook-addon';
+import {
+	type Locale,
+	overwriteGetLocale,
+	overwriteSetLocale,
+	setLocale
+} from '../src/lib/paraglide/runtime';
 
-initialize();
+import '../src/app.css';
+
+mswInitialize({
+	onUnhandledRequest(req, p) {
+		if (/src/g.test(req.url) || /@id/g.test(req.url)) return;
+		p.warning();
+	}
+});
+
+let localeState: Locale | undefined = undefined;
+overwriteGetLocale(() => localeState || 'en');
+overwriteSetLocale((nw) => {
+	if (localeState !== undefined) window.location.reload();
+	localeState = nw;
+});
 
 const preview: Preview = {
 	loaders: [mswLoader],
@@ -17,8 +35,9 @@ const preview: Preview = {
 		}
 	},
 	globalTypes: {
-		lang: {
+		locale: {
 			description: 'Language',
+			defaultValue: 'en' satisfies Locale,
 			toolbar: {
 				icon: 'globe',
 				dynamicTitle: true,
@@ -27,18 +46,11 @@ const preview: Preview = {
 					{ value: 'ja', title: 'Japanese' },
 					{ value: 'ko', title: 'Korean' },
 					{ value: 'zh-cn', title: 'Chinese (Simplified)' }
-				]
+				] satisfies { value: Locale; title: string }[]
 			}
 		}
 	},
-	initialGlobals: {
-		lang: 'en'
-	},
 	decorators: [
-		(story, ctx) => {
-			if (ctx.globals?.lang) setLocale(ctx.globals.lang);
-			return story();
-		},
 		(story) => {
 			const s = story();
 			document.body.style.backgroundColor = 'var(--otodb-color-bg-primary)';
@@ -55,7 +67,12 @@ const preview: Preview = {
 			},
 			defaultTheme: 'default',
 			attributeName: 'data-theme'
-		})
+		}),
+		(storyFn, context) => {
+			const currentLocale = context.globals?.locale as Locale | undefined;
+			if (currentLocale) setLocale(currentLocale);
+			return storyFn();
+		}
 	]
 };
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -46,6 +46,7 @@ All three commands must succeed without errors before committing. Do not skip or
 ## Coding
 
 - When importing components or libraries in `lib`, use `$lib` for import path.
+- Write story by Typescript. e.g. `*.stories.ts`
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

- `preview.ts`: paraglide の locale get/set を上書きして Storybook 内でロケール状態を管理するように変更
- `preview.ts`: Storybook のツールバーに言語切り替え (en/ja/ko/zh-cn) を追加
- `preview.ts`: MSW の unhandled request ハンドラーをアセット・Vite リクエストのノイズを抑制するように修正
- `AGENTS.md`: ストーリーは TypeScript で書く規約を追記

## Test plan

- [ ] Storybook 起動後、ツールバーに言語切り替えが表示されることを確認
- [ ] 言語を切り替えると UI のロケールが反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)