### PR TITLE
Update Nicopedia URL regex to include u and l

### DIFF
--- a/backend/otodb/api/tag.py
+++ b/backend/otodb/api/tag.py
@@ -822,7 +822,7 @@ tag_work_connection_parser = make_alt_value_parser(
 	(
 		TagWorkConnectionTypes.NICOPEDIA,
 		re_to_parser(
-			re.compile(r'https?:\/\/dic\.nicovideo\.jp\/((?:a|v)\/[^/?#]+)\/?')
+			re.compile(r'https?:\/\/dic\.nicovideo\.jp\/((?:a|v|u|l)\/[^/?#]+)\/?')
 		),
 	),
 	(


### PR DESCRIPTION
See https://otodb.net/tag/世始皇#c353

a = tag (presumably "a" stood for "article"), v = video, u = user, l = live

<img width="756" height="590" alt="image" src="https://github.com/user-attachments/assets/56504076-c17f-4425-95de-7c7c89bee87c" />
