### PR TITLE
Batch relation editor

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -122,6 +122,7 @@
 	"bald_clear_marlin_grasp": "Entries",
 	"front_smart_hound_fold": "Pending entries",
 	"less_green_angelfish_hunt": "Swap",
+	"mild_bold_finch_mix": "(multiple)",
 	"grand_vexed_snail_ripple": "is a",
 	"clean_best_kangaroo_achieve": "of",
 	"stout_frail_warbler_support": "This",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -122,6 +122,7 @@
 	"bald_clear_marlin_grasp": "エントリー",
 	"front_smart_hound_fold": "エントリー（審査中）",
 	"less_green_angelfish_hunt": "スワップ",
+	"mild_bold_finch_mix": "（複数）",
 	"grand_vexed_snail_ripple": "は",
 	"clean_best_kangaroo_achieve": "の",
 	"stout_frail_warbler_support": "この",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -122,6 +122,7 @@
 	"bald_clear_marlin_grasp": "작품",
 	"front_smart_hound_fold": "작품(검토중)",
 	"less_green_angelfish_hunt": "교환하기",
+	"mild_bold_finch_mix": "(여러)",
 	"grand_vexed_snail_ripple": "는",
 	"clean_best_kangaroo_achieve": "의",
 	"stout_frail_warbler_support": "이",

--- a/frontend/messages/zh-cn.json
+++ b/frontend/messages/zh-cn.json
@@ -122,6 +122,7 @@
 	"bald_clear_marlin_grasp": "作品",
 	"front_smart_hound_fold": "作品（审核中）",
 	"less_green_angelfish_hunt": "交换",
+	"mild_bold_finch_mix": "（多个）",
 	"grand_vexed_snail_ripple": "为",
 	"clean_best_kangaroo_achieve": "的",
 	"stout_frail_warbler_support": "本",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -23,12 +23,30 @@
 		background-color: color-mix(in hsl, transparent 40%, var(--otodb-color-bg-fainter));
 	}
 
-	tbody > tr:not(form *):hover {
-		background-color: color-mix(
-			in hsl,
-			var(--otodb-color-bg-fainter) 80%,
-			var(--otodb-color-content-primary)
-		);
+	tbody {
+		& > tr:hover {
+			background-color: color-mix(
+				in hsl,
+				var(--otodb-color-bg-fainter) 80%,
+				var(--otodb-color-content-primary)
+			);
+		}
+
+		& > tr.selected {
+			background-color: color-mix(
+				in hsl,
+				var(--otodb-color-bg-faint) 60%,
+				var(--otodb-color-content-fainter)
+			);
+
+			&:hover {
+				background-color: color-mix(
+					in hsl,
+					var(--otodb-color-bg-faint) 40%,
+					var(--otodb-color-content-fainter)
+				);
+			}
+		}
 	}
 
 	ul {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -32,7 +32,7 @@
 			);
 		}
 
-		& > tr.selected {
+		& > tr:has(input:checked) {
 			background-color: color-mix(
 				in hsl,
 				var(--otodb-color-bg-faint) 60%,

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -32,7 +32,7 @@
 			);
 		}
 
-		& > tr:has(input:checked) {
+		& > tr:has(input[type="checkbox"]:checked) {
 			background-color: color-mix(
 				in hsl,
 				var(--otodb-color-bg-faint) 60%,

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -15,6 +15,10 @@
 @custom-variant dark (@media not (prefers-color-scheme: light), &:where(.dark, .dark *), &:has(#bg-marker.dark));
 
 @layer base {
+	input {
+		accent-color: var(--otodb-color-content-primary);
+	}
+
 	thead {
 		background-color: var(--otodb-color-bg-primary);
 	}
@@ -23,30 +27,12 @@
 		background-color: color-mix(in hsl, transparent 40%, var(--otodb-color-bg-fainter));
 	}
 
-	tbody {
-		& > tr:hover {
-			background-color: color-mix(
-				in hsl,
-				var(--otodb-color-bg-fainter) 80%,
-				var(--otodb-color-content-primary)
-			);
-		}
-
-		& > tr:has(input[type='checkbox']:checked) {
-			background-color: color-mix(
-				in hsl,
-				var(--otodb-color-bg-faint) 60%,
-				var(--otodb-color-content-fainter)
-			);
-
-			&:hover {
-				background-color: color-mix(
-					in hsl,
-					var(--otodb-color-bg-faint) 40%,
-					var(--otodb-color-content-fainter)
-				);
-			}
-		}
+	tbody > tr:hover {
+		background-color: color-mix(
+			in hsl,
+			var(--otodb-color-bg-fainter) 80%,
+			var(--otodb-color-content-primary)
+		);
 	}
 
 	ul {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -15,10 +15,6 @@
 @custom-variant dark (@media not (prefers-color-scheme: light), &:where(.dark, .dark *), &:has(#bg-marker.dark));
 
 @layer base {
-	input {
-		accent-color: var(--otodb-color-content-primary);
-	}
-
 	thead {
 		background-color: var(--otodb-color-bg-primary);
 	}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -32,7 +32,7 @@
 			);
 		}
 
-		& > tr:has(input[type="checkbox"]:checked) {
+		& > tr:has(input[type='checkbox']:checked) {
 			background-color: color-mix(
 				in hsl,
 				var(--otodb-color-bg-faint) 60%,

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -32,10 +32,16 @@
 	type Work = components['schemas']['ThinWorkSchema'];
 	type Song = components['schemas']['SongSchema'];
 
-	let relations: { swapped: boolean; item: Work | Song; relation: number }[] = $state(
+	let relations: {
+		selected: boolean;
+		swapped: boolean;
+		item: Work | Song;
+		relation: number;
+	}[] = $state(
 		init_relations[0]
 			.filter(({ A_id, B_id }) => A_id === this_id || B_id === this_id)
 			.map(({ A_id, B_id, relation }) => ({
+				selected: false,
 				swapped: A_id === this_id,
 				item: init_relations[1].find((e) => e.id === (A_id === this_id ? B_id : A_id)) as
 					| Work
@@ -45,6 +51,16 @@
 	);
 
 	let new_item: null | Work | Song = $state(null);
+
+	const any_selected = $derived(relations.some((r) => r.selected));
+	const all_selected = $derived(relations.length > 0 && relations.every((r) => r.selected));
+	const uniform_relation = $derived.by(() => {
+		const selected = relations.filter((r) => r.selected);
+		if (selected.length === 0) return null;
+		const first = selected[0].relation;
+		if (!selected.every((r) => r.relation === first)) return null;
+		return enumValues(RelationType).find((r) => r === first) ?? null;
+	});
 
 	const endpoint = $derived(obj_type === 'work' ? '/api/work/relation' : '/api/tag/song_relation');
 	const post_gate = { p: Promise.withResolvers<void>() };
@@ -107,7 +123,12 @@
 					!relations.some((r) => r.item.id === new_item!.id)
 				) {
 					e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
-					relations.unshift({ swapped: false, item: new_item, relation: 0 });
+					relations.unshift({
+						selected: false,
+						swapped: false,
+						item: new_item,
+						relation: 0
+					});
 					new_item = null;
 				}
 			}}
@@ -115,10 +136,88 @@
 			disabled={!new_item}>{m.swift_dry_gecko_boost()}</button
 		>
 	</div>
+	{#snippet batch_select()}
+		<select
+			disabled={!any_selected}
+			value={uniform_relation ?? ''}
+			onchange={(e) => {
+				const v = e.currentTarget.value;
+				if (v === '') return;
+				const num = Number(v);
+				relations.forEach((r) => {
+					if (r.selected) r.relation = num;
+				});
+			}}
+		>
+			{#if uniform_relation === null}
+				<option value="" disabled={any_selected}
+					>{any_selected ? m.mild_bold_finch_mix() : '---'}</option
+				>
+			{/if}
+			{#each enumValues(RelationType) as rel, j (j)}
+				<option value={rel}>{Predicates[rel]()}</option>
+			{/each}
+		</select>
+	{/snippet}
 	<table>
+		{#if relations.length > 0}
+			<thead>
+				<tr>
+					<th
+						><input
+							type="checkbox"
+							checked={all_selected}
+							onchange={(e) => {
+								e.stopPropagation();
+								const v = e.currentTarget.checked;
+								relations.forEach((r) => (r.selected = v));
+							}}
+						/></th
+					>
+					<th></th>
+					{#if isSOV(getLocale())}
+						<th></th>
+						<th></th>
+						<th>{@render batch_select()}</th>
+					{:else}
+						<th>{@render batch_select()}</th>
+						<th></th>
+					{/if}
+					<th
+						><button
+							type="button"
+							disabled={!any_selected}
+							onclick={(e) => {
+								e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
+								relations.forEach((r) => {
+									if (r.selected) r.swapped = !r.swapped;
+								});
+							}}>{m.less_green_angelfish_hunt()}</button
+						></th
+					>
+					<th
+						><button
+							type="button"
+							disabled={!any_selected}
+							onclick={(e) => {
+								e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
+								relations = relations.filter((r) => !r.selected);
+							}}>{m.even_alert_grebe_taste()}</button
+						></th
+					>
+				</tr>
+			</thead>
+		{/if}
 		<tbody>
 			{#each relations as relation, i (i)}
 				<tr>
+					<td
+						><input
+							type="checkbox"
+							bind:checked={relation.selected}
+							onchange={(e) => e.stopPropagation()}
+						/></td
+					>
 					<td class="w-64">{@render work(relation, !relation.swapped)}</td>
 					{#if isSOV(getLocale())}
 						<td>{m.grand_vexed_snail_ripple()}</td>
@@ -163,3 +262,9 @@
 		</tbody>
 	</table>
 </form>
+
+<style>
+	th {
+		font-weight: normal;
+	}
+</style>

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -300,4 +300,20 @@
 	th {
 		font-weight: normal;
 	}
+
+	tbody > tr:has(input[type='checkbox']:checked) {
+		background-color: color-mix(
+			in hsl,
+			var(--otodb-color-bg-faint) 60%,
+			var(--otodb-color-content-fainter)
+		);
+
+		&:hover {
+			background-color: color-mix(
+				in hsl,
+				var(--otodb-color-bg-faint) 40%,
+				var(--otodb-color-content-fainter)
+			);
+		}
+	}
 </style>

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -217,8 +217,8 @@
 			{#each relations as relation, i (i)}
 				<tr
 					onmouseenter={(e) => {
-						if (e.buttons !== 1 || !drag_active) return;
-						relation.selected = !relation.selected;
+						if (e.buttons !== 1 || !drag_active || last_clicked_index === null) return;
+						relation.selected = relations[last_clicked_index].selected;
 					}}
 				>
 					<td
@@ -226,7 +226,7 @@
 							if (e.button !== 0) return;
 							e.preventDefault();
 							if (e.shiftKey && last_clicked_index !== null) {
-								const new_state = !relation.selected;
+								const new_state = relations[last_clicked_index].selected;
 								const lo = Math.min(last_clicked_index, i);
 								const hi = Math.max(last_clicked_index, i);
 								for (let k = lo; k <= hi; k++) relations[k].selected = new_state;

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -106,12 +106,7 @@
 	{/if}
 {/snippet}
 
-<svelte:window
-	onmousedown={(e) => {
-		if (e.button === 0) drag_active = true;
-	}}
-	onmouseup={() => (drag_active = false)}
-/>
+<svelte:window onmouseup={() => (drag_active = false)} />
 
 <form
 	method="POST"
@@ -220,7 +215,12 @@
 		{/if}
 		<tbody>
 			{#each relations as relation, i (i)}
-				<tr>
+				<tr
+					onmouseenter={(e) => {
+						if (e.buttons !== 1 || !drag_active) return;
+						relation.selected = !relation.selected;
+					}}
+				>
 					<td
 						><input
 							type="checkbox"
@@ -237,10 +237,7 @@
 									relation.selected = !relation.selected;
 								}
 								last_clicked_index = i;
-							}}
-							onmouseenter={(e) => {
-								if (e.buttons !== 1 || !drag_active) return;
-								relation.selected = !relation.selected;
+								drag_active = true;
 							}}
 							onkeydown={(e) => {
 								if (e.key === ' ') {

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -218,7 +218,10 @@
 				<tr
 					onmouseenter={(e) => {
 						if (e.buttons !== 1 || !drag_active || last_clicked_index === null) return;
-						relation.selected = relations[last_clicked_index].selected;
+						const new_state = relations[last_clicked_index].selected;
+						const lo = Math.min(last_clicked_index, i);
+						const hi = Math.max(last_clicked_index, i);
+						for (let k = lo; k <= hi; k++) relations[k].selected = new_state;
 					}}
 				>
 					<td

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -215,7 +215,7 @@
 		{/if}
 		<tbody>
 			{#each relations as relation, i (i)}
-				<tr>
+				<tr class:selected={relation.selected}>
 					<td
 						><input
 							type="checkbox"

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -52,8 +52,18 @@
 
 	let new_item: null | Work | Song = $state(null);
 
-	let drag_active = $state(false);
 	let last_clicked_index: number | null = $state(null);
+	let last_entered_index: number | null = $state(null);
+	let last_lo = $derived(
+		last_clicked_index !== null && last_entered_index !== null
+			? Math.min(last_clicked_index, last_entered_index)
+			: null
+	);
+	let last_hi = $derived(
+		last_clicked_index !== null && last_entered_index !== null
+			? Math.max(last_clicked_index, last_entered_index)
+			: null
+	);
 
 	const any_selected = $derived(relations.some((r) => r.selected));
 	const all_selected = $derived(relations.length > 0 && relations.every((r) => r.selected));
@@ -106,7 +116,15 @@
 	{/if}
 {/snippet}
 
-<svelte:window onmouseup={() => (drag_active = false)} />
+<svelte:window
+	onmouseup={() => {
+		if (last_lo !== null && last_hi !== null && last_clicked_index !== null)
+			for (let i = last_lo; i <= last_hi; i++)
+				relations[i].selected = relations[last_clicked_index].selected;
+		last_clicked_index = null;
+		last_entered_index = null;
+	}}
+/>
 
 <form
 	method="POST"
@@ -172,6 +190,7 @@
 						><input
 							type="checkbox"
 							checked={all_selected}
+							indeterminate={!all_selected && any_selected}
 							onchange={(e) => {
 								e.stopPropagation();
 								const v = e.currentTarget.checked;
@@ -217,31 +236,36 @@
 			{#each relations as relation, i (i)}
 				<tr
 					onmouseenter={(e) => {
-						if (e.buttons !== 1 || !drag_active || last_clicked_index === null) return;
-						const new_state = relations[last_clicked_index].selected;
-						const lo = Math.min(last_clicked_index, i);
-						const hi = Math.max(last_clicked_index, i);
-						for (let k = lo; k <= hi; k++) relations[k].selected = new_state;
+						if (e.buttons !== 1 || last_clicked_index === null) return;
+						last_entered_index = i;
 					}}
 				>
 					<td
 						onmousedown={(e) => {
 							if (e.button !== 0) return;
 							e.preventDefault();
-							if (e.shiftKey && last_clicked_index !== null) {
-								const new_state = relations[last_clicked_index].selected;
-								const lo = Math.min(last_clicked_index, i);
-								const hi = Math.max(last_clicked_index, i);
-								for (let k = lo; k <= hi; k++) relations[k].selected = new_state;
+							if (e.shiftKey) {
+								const selected_indices = relations.flatMap((r, idx) => (r.selected ? [idx] : []));
+								if (selected_indices.length) {
+									const lo = Math.min(...selected_indices);
+									const hi = Math.max(...selected_indices);
+									if (i < lo) for (let k = i; k < lo; k++) relations[k].selected = true;
+									else if (i > hi) for (let k = hi + 1; k <= i; k++) relations[k].selected = true;
+									else relation.selected = !relation.selected;
+								}
 							} else {
 								relation.selected = !relation.selected;
 							}
 							last_clicked_index = i;
-							drag_active = true;
 						}}
 						><input
 							type="checkbox"
-							checked={relation.selected}
+							checked={last_clicked_index !== null &&
+							last_entered_index !== null &&
+							last_lo <= i &&
+							i <= last_hi
+								? relations[last_clicked_index].selected
+								: relation.selected}
 							onclick={(e) => e.preventDefault()}
 							onkeydown={(e) => {
 								if (e.key === ' ') {

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -262,6 +262,8 @@
 							type="checkbox"
 							checked={last_clicked_index !== null &&
 							last_entered_index !== null &&
+							last_lo !== null &&
+							last_hi !== null &&
 							last_lo <= i &&
 							i <= last_hi
 								? relations[last_clicked_index].selected

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -215,7 +215,7 @@
 		{/if}
 		<tbody>
 			{#each relations as relation, i (i)}
-				<tr class:selected={relation.selected}>
+				<tr>
 					<td
 						><input
 							type="checkbox"

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -52,6 +52,9 @@
 
 	let new_item: null | Work | Song = $state(null);
 
+	let drag_active = $state(false);
+	let last_clicked_index: number | null = $state(null);
+
 	const any_selected = $derived(relations.some((r) => r.selected));
 	const all_selected = $derived(relations.length > 0 && relations.every((r) => r.selected));
 	const uniform_relation = $derived.by(() => {
@@ -102,6 +105,8 @@
 		{m.stout_frail_warbler_support()}{m.great_clean_beaver_amuse()}{#if obj_type === 'work'}{m.grand_merry_fly_succeed()}{:else if obj_type === 'song'}{m.grand_nice_pony_belong()}{/if}
 	{/if}
 {/snippet}
+
+<svelte:window onmouseup={() => (drag_active = false)} />
 
 <form
 	method="POST"
@@ -214,8 +219,31 @@
 					<td
 						><input
 							type="checkbox"
-							bind:checked={relation.selected}
-							onchange={(e) => e.stopPropagation()}
+							checked={relation.selected}
+							onclick={(e) => e.preventDefault()}
+							onmousedown={(e) => {
+								if (e.button !== 0) return;
+								if (e.shiftKey && last_clicked_index !== null) {
+									const new_state = !relation.selected;
+									const lo = Math.min(last_clicked_index, i);
+									const hi = Math.max(last_clicked_index, i);
+									for (let k = lo; k <= hi; k++) relations[k].selected = new_state;
+								} else {
+									relation.selected = !relation.selected;
+								}
+								last_clicked_index = i;
+								drag_active = true;
+							}}
+							onmouseenter={(e) => {
+								if (e.buttons !== 1 || !drag_active) return;
+								relation.selected = !relation.selected;
+							}}
+							onkeydown={(e) => {
+								if (e.key === ' ') {
+									e.preventDefault();
+									relation.selected = !relation.selected;
+								}
+							}}
 						/></td
 					>
 					<td class="w-64">{@render work(relation, !relation.swapped)}</td>

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -222,23 +222,24 @@
 					}}
 				>
 					<td
+						onmousedown={(e) => {
+							if (e.button !== 0) return;
+							e.preventDefault();
+							if (e.shiftKey && last_clicked_index !== null) {
+								const new_state = !relation.selected;
+								const lo = Math.min(last_clicked_index, i);
+								const hi = Math.max(last_clicked_index, i);
+								for (let k = lo; k <= hi; k++) relations[k].selected = new_state;
+							} else {
+								relation.selected = !relation.selected;
+							}
+							last_clicked_index = i;
+							drag_active = true;
+						}}
 						><input
 							type="checkbox"
 							checked={relation.selected}
 							onclick={(e) => e.preventDefault()}
-							onmousedown={(e) => {
-								if (e.button !== 0) return;
-								if (e.shiftKey && last_clicked_index !== null) {
-									const new_state = !relation.selected;
-									const lo = Math.min(last_clicked_index, i);
-									const hi = Math.max(last_clicked_index, i);
-									for (let k = lo; k <= hi; k++) relations[k].selected = new_state;
-								} else {
-									relation.selected = !relation.selected;
-								}
-								last_clicked_index = i;
-								drag_active = true;
-							}}
 							onkeydown={(e) => {
 								if (e.key === ' ') {
 									e.preventDefault();

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -106,7 +106,12 @@
 	{/if}
 {/snippet}
 
-<svelte:window onmouseup={() => (drag_active = false)} />
+<svelte:window
+	onmousedown={(e) => {
+		if (e.button === 0) drag_active = true;
+	}}
+	onmouseup={() => (drag_active = false)}
+/>
 
 <form
 	method="POST"
@@ -232,7 +237,6 @@
 									relation.selected = !relation.selected;
 								}
 								last_clicked_index = i;
-								drag_active = true;
 							}}
 							onmouseenter={(e) => {
 								if (e.buttons !== 1 || !drag_active) return;


### PR DESCRIPTION
Can select items individually, all/none, left-click drag, or shift-click range select. Selected items can then have their type of relation and direction modified, or be removed. Relation type dropdown updates accordingly to what is selected (shows the value if all are the same, "(multiple)" if not).

An example case is adding a bunch of song relations to a medley, and then batch applying the correct relation type and direction.

I'm OK if we want to remove the drag and shift select to keep the code a bit simpler.