### PR TITLE
Add `/work/{id}/embed` and `/work/{id}/{platform}` routes

### DIFF
--- a/frontend/src/lib/embed_redirect.ts
+++ b/frontend/src/lib/embed_redirect.ts
@@ -1,0 +1,44 @@
+import { redirect } from '@sveltejs/kit';
+import client from '$lib/api.server';
+import { Platform, WorkStatus, type components } from '$lib/schema';
+
+type WorkSource = components['schemas']['WorkSourceSchema'];
+
+const UNFURLER_UA =
+	/Discordbot|Twitterbot|Slackbot|TelegramBot|WhatsApp|facebookexternalhit|redditbot|Pinterest|vkShare|Mastodon|Pleroma|Misskey|Akkoma|Bluesky/i;
+
+const EMBED_FIXER_HOSTNAMES: Partial<Record<Platform, string>> = {
+	[Platform.Niconico]: 'nicovideo.gay',
+	[Platform.Bilibili]: 'vxbilibili.com',
+	[Platform.Twitter]: 'fixupx.com'
+};
+
+function rewriteForEmbed(platform: Platform, rawUrl: string): string {
+	const u = new URL(rawUrl);
+	const newHost = EMBED_FIXER_HOSTNAMES[platform];
+	if (newHost) u.hostname = newHost;
+	return u.toString();
+}
+
+export async function redirectToEmbedSource(
+	workId: string,
+	request: Request,
+	fetch: typeof globalThis.fetch,
+	predicate: (s: WorkSource) => boolean = () => true
+): Promise<never> {
+	const workPath = `/work/${workId}`;
+
+	const { data: sources } = await client.GET('/api/work/sources', {
+		params: { query: { work_id: workId } },
+		fetch
+	});
+
+	const source = sources?.find((s) => s.work_status !== WorkStatus.Down && predicate(s));
+	if (!source) redirect(302, workPath);
+
+	const ua = request.headers.get('user-agent') ?? '';
+	if (UNFURLER_UA.test(ua)) {
+		redirect(302, rewriteForEmbed(source.platform, source.url));
+	}
+	redirect(302, workPath);
+}

--- a/frontend/src/routes/work/[work_id]/[platform]/+server.ts
+++ b/frontend/src/routes/work/[work_id]/[platform]/+server.ts
@@ -1,0 +1,45 @@
+import { redirect } from '@sveltejs/kit';
+import client from '$lib/api.server';
+import { PlatformNames } from '$lib/enums';
+import { Platform, WorkStatus } from '$lib/schema';
+import type { RequestHandler } from './$types';
+
+const UNFURLER_UA =
+	/Discordbot|Twitterbot|Slackbot|TelegramBot|WhatsApp|facebookexternalhit|redditbot|Pinterest|vkShare|Mastodon|Pleroma|Misskey|Akkoma|Bluesky/i;
+
+const PLATFORM_BY_NAME = new Map<string, Platform>(
+	Object.entries(PlatformNames).map(([k, v]) => [v.toLowerCase(), Number(k) as Platform])
+);
+
+const EMBED_FIXER_HOSTNAMES: Partial<Record<Platform, string>> = {
+	[Platform.Niconico]: 'nicovideo.gay',
+	[Platform.Bilibili]: 'vxbilibili.com',
+	[Platform.Twitter]: 'fixupx.com'
+};
+
+function rewriteForEmbed(platform: Platform, rawUrl: string): string {
+	const u = new URL(rawUrl);
+	const newHost = EMBED_FIXER_HOSTNAMES[platform];
+	if (newHost) u.hostname = newHost;
+	return u.toString();
+}
+
+export const GET: RequestHandler = async ({ params, request, fetch }) => {
+	const workPath = `/work/${params.work_id}`;
+	const platform = PLATFORM_BY_NAME.get(params.platform.toLowerCase());
+	if (platform === undefined) redirect(302, workPath);
+
+	const { data: sources } = await client.GET('/api/work/sources', {
+		params: { query: { work_id: params.work_id } },
+		fetch
+	});
+
+	const source = sources?.find((s) => s.platform === platform && s.work_status !== WorkStatus.Down);
+	if (!source) redirect(302, workPath);
+
+	const ua = request.headers.get('user-agent') ?? '';
+	if (UNFURLER_UA.test(ua)) {
+		redirect(302, rewriteForEmbed(platform, source.url));
+	}
+	redirect(302, workPath);
+};

--- a/frontend/src/routes/work/[work_id]/[platform]/+server.ts
+++ b/frontend/src/routes/work/[work_id]/[platform]/+server.ts
@@ -1,45 +1,17 @@
 import { redirect } from '@sveltejs/kit';
-import client from '$lib/api.server';
+import { redirectToEmbedSource } from '$lib/embed_redirect';
 import { PlatformNames } from '$lib/enums';
-import { Platform, WorkStatus } from '$lib/schema';
+import { Platform } from '$lib/schema';
 import type { RequestHandler } from './$types';
-
-const UNFURLER_UA =
-	/Discordbot|Twitterbot|Slackbot|TelegramBot|WhatsApp|facebookexternalhit|redditbot|Pinterest|vkShare|Mastodon|Pleroma|Misskey|Akkoma|Bluesky/i;
 
 const PLATFORM_BY_NAME = new Map<string, Platform>(
 	Object.entries(PlatformNames).map(([k, v]) => [v.toLowerCase(), Number(k) as Platform])
 );
-
-const EMBED_FIXER_HOSTNAMES: Partial<Record<Platform, string>> = {
-	[Platform.Niconico]: 'nicovideo.gay',
-	[Platform.Bilibili]: 'vxbilibili.com',
-	[Platform.Twitter]: 'fixupx.com'
-};
-
-function rewriteForEmbed(platform: Platform, rawUrl: string): string {
-	const u = new URL(rawUrl);
-	const newHost = EMBED_FIXER_HOSTNAMES[platform];
-	if (newHost) u.hostname = newHost;
-	return u.toString();
-}
 
 export const GET: RequestHandler = async ({ params, request, fetch }) => {
 	const workPath = `/work/${params.work_id}`;
 	const platform = PLATFORM_BY_NAME.get(params.platform.toLowerCase());
 	if (platform === undefined) redirect(302, workPath);
 
-	const { data: sources } = await client.GET('/api/work/sources', {
-		params: { query: { work_id: params.work_id } },
-		fetch
-	});
-
-	const source = sources?.find((s) => s.platform === platform && s.work_status !== WorkStatus.Down);
-	if (!source) redirect(302, workPath);
-
-	const ua = request.headers.get('user-agent') ?? '';
-	if (UNFURLER_UA.test(ua)) {
-		redirect(302, rewriteForEmbed(platform, source.url));
-	}
-	redirect(302, workPath);
+	return redirectToEmbedSource(params.work_id, request, fetch, (s) => s.platform === platform);
 };

--- a/frontend/src/routes/work/[work_id]/embed/+server.ts
+++ b/frontend/src/routes/work/[work_id]/embed/+server.ts
@@ -1,0 +1,5 @@
+import { redirectToEmbedSource } from '$lib/embed_redirect';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = ({ params, request, fetch }) =>
+	redirectToEmbedSource(params.work_id, request, fetch);


### PR DESCRIPTION
Endpoints to allow embedding works on platforms like Discord.