### PR TITLE
Add `/db{work_id}` route

### DIFF
--- a/frontend/src/routes/db[work_id]/[...rest]/+server.ts
+++ b/frontend/src/routes/db[work_id]/[...rest]/+server.ts
@@ -1,0 +1,7 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = ({ params, url }) => {
+	const suffix = params.rest ? `/${params.rest}` : '';
+	redirect(301, `/work/${params.work_id}${suffix}${url.search}`);
+};


### PR DESCRIPTION
We actually already support this via Caddy (https://otodb.net/db1) but I think it makes sense to live here