### PR TITLE
Preserve domain attribute when relaying auth cookies

### DIFF
--- a/frontend/src/lib/api.server.ts
+++ b/frontend/src/lib/api.server.ts
@@ -74,11 +74,12 @@ export const rawClient = createClient<paths>({
 });
 
 export const forwardCookies = (cookies: Cookies, response: Response) => {
-	for (const { name, value, expires, maxAge, sameSite } of setCookie.parse(
+	for (const { name, value, domain, expires, maxAge, sameSite } of setCookie.parse(
 		response.headers.getSetCookie()
 	))
 		cookies.set(name, value, {
 			path: '/',
+			domain,
 			expires,
 			maxAge,
 			sameSite: sameSite as CookieSerializeOptions['sameSite']


### PR DESCRIPTION
Makes https://github.com/otoDB/otoDB/pull/759 actually work