### PR TITLE
Prevent normal user reopening when another user has edited OP

### DIFF
--- a/backend/otodb/api/thread.py
+++ b/backend/otodb/api/thread.py
@@ -369,10 +369,12 @@ def close_thread(request: AuthedHttpRequest, thread_id: OtodbID):
 @transaction.atomic
 def reopen_thread(request: AuthedHttpRequest, thread_id: OtodbID):
 	t = get_object_or_404(Thread, id=thread_id, is_removed=False)
-	is_mod = request.user.is_mod
-	is_author = t.added_by_id == request.user.pk
-	if not (is_mod or is_author):
-		raise HttpError(403, 'Forbidden')
+	if not request.user.is_mod:
+		if t.added_by_id != request.user.pk:
+			raise HttpError(403, 'Forbidden')
+		op = t.posts.get(num=1)
+		if op.edited_by_id and op.edited_by_id != op.user_id:
+			raise HttpError(403, 'Forbidden')
 	if t.closed_at:
 		t.closed_at = None
 		t.save(update_fields=['closed_at'])

--- a/backend/otodb/models/posts.py
+++ b/backend/otodb/models/posts.py
@@ -132,6 +132,7 @@ class Thread(models.Model):
 		entitylink_set: QuerySet['EntityLink']
 		_entity_links: list['EntityLink']
 		posts: QuerySet['ThreadPost']
+		added_by_id: int
 
 	class Meta:
 		verbose_name = 'Thread'
@@ -161,6 +162,10 @@ class ThreadPost(models.Model):
 		related_name='edited_threadposts',
 	)
 	is_removed = models.BooleanField(default=False, db_index=True)
+
+	if TYPE_CHECKING:
+		user_id: int
+		edited_by_id: int
 
 	class Meta:
 		ordering = ['num']

--- a/backend/tests/test_PUT_thread_reopen.py
+++ b/backend/tests/test_PUT_thread_reopen.py
@@ -87,6 +87,59 @@ def test_reopen_thread_forbidden_for_non_admin_non_author(other_member, member):
 
 
 @pytest.mark.django_db
+def test_reopen_forbidden_for_author_when_op_edited_by_mod(
+	thread_client, member, admin
+):
+	"""Author cannot reopen once a mod has edited the OP (mod intervention)."""
+	t = make_closed_thread(member)
+	op = t.posts.get(num=1)
+	op.edited_by = admin
+	op.edited_at = datetime.now(tz=timezone.utc)
+	op.save(update_fields=['edited_by', 'edited_at'])
+	original_closed_at = t.closed_at
+
+	response = thread_client.put(f'/reopen?thread_id={t.pk}')
+
+	assert response.status_code == 403
+	t.refresh_from_db()
+	assert t.closed_at == original_closed_at
+
+
+@pytest.mark.django_db
+def test_reopen_allowed_for_author_when_op_edited_by_self(thread_client, member):
+	"""An author editing their own OP does not lock reopening."""
+	t = make_closed_thread(member)
+	op = t.posts.get(num=1)
+	op.edited_by = member
+	op.edited_at = datetime.now(tz=timezone.utc)
+	op.save(update_fields=['edited_by', 'edited_at'])
+
+	response = thread_client.put(f'/reopen?thread_id={t.pk}')
+
+	assert response.status_code == 200
+	t.refresh_from_db()
+	assert t.closed_at is None
+
+
+@pytest.mark.django_db
+def test_reopen_allowed_for_mod_when_op_edited_by_mod(
+	admin_thread_client, member, admin
+):
+	"""A mod can still reopen even after the OP was edited by a mod."""
+	t = make_closed_thread(member)
+	op = t.posts.get(num=1)
+	op.edited_by = admin
+	op.edited_at = datetime.now(tz=timezone.utc)
+	op.save(update_fields=['edited_by', 'edited_at'])
+
+	response = admin_thread_client.put(f'/reopen?thread_id={t.pk}')
+
+	assert response.status_code == 200
+	t.refresh_from_db()
+	assert t.closed_at is None
+
+
+@pytest.mark.django_db
 def test_reopen_already_open_thread(admin_thread_client, admin):
 	"""Reopening a thread that is not closed is a no-op."""
 	t = Thread.objects.create(


### PR DESCRIPTION
Related to https://github.com/otoDB/otoDB/pull/787/