### PR TITLE
Change invite code link to /wiki/about

### DIFF
--- a/frontend/src/routes/(auth)/register/+page.svelte
+++ b/frontend/src/routes/(auth)/register/+page.svelte
@@ -37,7 +37,7 @@
 					<tr>
 						<th
 							><label for="invite"
-								>{m.tiny_great_robin_commend()} (<a href="/thread/19">?</a>)</label
+								>{m.tiny_great_robin_commend()} (<a href="/wiki/about">?</a>)</label
 							></th
 						>
 						<td><input required type="text" name="invite" /></td>


### PR DESCRIPTION
Makes this a stable link since it's defined in our fixtures, and also we will mention on this page whenever invites may be required (expected only short term)