### PR TITLE
Temporary view to set user role

### DIFF
--- a/backend/otodb/templates/base.html
+++ b/backend/otodb/templates/base.html
@@ -15,6 +15,7 @@
 	<body>
 		 <nav>
 		   <a href="{% url 'otodb:upload_cookies' %}">Upload Cookies</a>
+		   {% if user.is_mod %}<a href="{% url 'otodb:set_user_role' %}">Set User Role</a>{% endif %}
 		 </nav>
 		<main>
 		  {% block content %}{% endblock content %}

--- a/backend/otodb/templates/base.html
+++ b/backend/otodb/templates/base.html
@@ -14,7 +14,7 @@
 	</head>
 	<body>
 		 <nav>
-		   <a href="{% url 'otodb:upload_cookies' %}">Upload Cookies</a>
+		   {% if user.is_admin %}<a href="{% url 'otodb:upload_cookies' %}">Upload Cookies</a>{% endif %}
 		   {% if user.is_mod %}<a href="{% url 'otodb:set_user_role' %}">Set User Role</a>{% endif %}
 		 </nav>
 		<main>

--- a/backend/otodb/templates/chores.html
+++ b/backend/otodb/templates/chores.html
@@ -1,0 +1,2 @@
+{% extends "base.html" %}
+{% block page_title %}Chores{% endblock page_title %}

--- a/backend/otodb/templates/set_user_role.html
+++ b/backend/otodb/templates/set_user_role.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block page_title %}Restrict User{% endblock page_title %}
+{% block page_title %}Set User Role{% endblock page_title %}
 
 {% block content %}
 <section>

--- a/backend/otodb/templates/set_user_role.html
+++ b/backend/otodb/templates/set_user_role.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block page_title %}Restrict User{% endblock page_title %}
+
+{% block content %}
+<section>
+    <h1>Set User Role</h1>
+    {% if message %}
+    <p><strong>{{ message }}</strong></p>
+    {% endif %}
+    <form target="_self" method="post">
+        {% csrf_token %}
+        <table>
+            {{ form.as_table }}
+        </table>
+      <input type="submit"/>
+    </form>
+</section>
+{% endblock content %}

--- a/backend/otodb/urls.py
+++ b/backend/otodb/urls.py
@@ -10,6 +10,6 @@ urlpatterns = [
 	path('api/', api.urls),
 	path('chores', views.chores, name='chores'),
 	path('chores/cookies', views.upload_cookies, name='upload_cookies'),
-	path('chores/restrict', views.set_user_role, name='set_user_role'),
+	path('chores/roles', views.set_user_role, name='set_user_role'),
 	path('auth_forward', views.auth_forward),
 ]

--- a/backend/otodb/urls.py
+++ b/backend/otodb/urls.py
@@ -8,6 +8,8 @@ app_name = 'otodb'
 urlpatterns = [
 	path('sitemap.xml', sitemap, name='sitemap'),
 	path('api/', api.urls),
+	path('chores', views.chores, name='chores'),
 	path('chores/cookies', views.upload_cookies, name='upload_cookies'),
+	path('chores/restrict', views.set_user_role, name='set_user_role'),
 	path('auth_forward', views.auth_forward),
 ]

--- a/backend/otodb/views.py
+++ b/backend/otodb/views.py
@@ -1,10 +1,19 @@
 from django import forms
 from django.conf import settings
+from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 
+from otodb.account.models import Account
+from otodb.api.common import AuthedHttpRequest
 from otodb.common import reset_cookies
+
+
+def chores(request: AuthedHttpRequest):
+	if not (request.user.is_authenticated and request.user.is_mod):
+		return HttpResponse(status=403)
+	return render(request, 'chores.html')
 
 
 class UploadForm(forms.Form):
@@ -36,3 +45,48 @@ def auth_forward(request: HttpRequest):
 	response['X-User-Name'] = user.username
 	response['X-User-Role'] = 'admin' if user.is_mod else 'editor'
 	return response
+
+
+# Temporary chore view for restricting users below.
+# To later be added to the main frontend.
+
+
+class SetUserRoleForm(forms.Form):
+	username = forms.CharField(max_length=127)
+	role = forms.ChoiceField(
+		choices=[
+			(Account.Levels.RESTRICTED, 'Restricted'),
+			(Account.Levels.MEMBER, 'Member'),
+		],
+		initial=Account.Levels.RESTRICTED,
+	)
+
+
+def set_user_role(request: AuthedHttpRequest):
+	if not (request.user.is_authenticated and request.user.is_mod):
+		return HttpResponse(status=403)
+
+	form = SetUserRoleForm(request.POST or None)
+	message = None
+	if form.is_valid():
+		target = Account.objects.filter(
+			username__iexact=form.cleaned_data['username']
+		).first()
+		if target is None:
+			form.add_error('username', 'No user with that username')
+		elif request.user.level <= target.level:
+			form.add_error('username', "You can't change this user's role")
+		else:
+			target.level = int(form.cleaned_data['role'])
+			target.save(update_fields=['level'])
+			label = Account.Levels(target.level).label
+			LogEntry.objects.log_actions(
+				user_id=request.user.id,
+				queryset=[target],
+				action_flag=CHANGE,
+				change_message=f'Set role to {label} via mod chore',
+			)
+			message = f'Set {target.username} to {label}'
+			form = SetUserRoleForm()
+
+	return render(request, 'set_user_role.html', {'form': form, 'message': message})


### PR DESCRIPTION
Until we get a proper way to do this in the frontend. Allows mods to set users below their role to member or restricted. Records changes via the Django admin LogEntry model. Accessible via `/chores/roles`

This should ideally coincide with #823 