### PR TITLE
Better relation editor UX

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8679,6 +8679,16 @@
           "category": {
             "$ref": "#/components/schemas/SongTagCategory"
           },
+          "aliased_to": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TagSongSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "lang_prefs": {
             "items": {
               "$ref": "#/components/schemas/TagLangPreferenceSchema"
@@ -8692,6 +8702,7 @@
           "name",
           "slug",
           "category",
+          "aliased_to",
           "lang_prefs"
         ],
         "title": "TagSongSchema",
@@ -9192,6 +9203,16 @@
           "category": {
             "$ref": "#/components/schemas/SongTagCategory"
           },
+          "aliased_to": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TagSongSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "lang_prefs": {
             "items": {
               "$ref": "#/components/schemas/TagLangPreferenceSchema"
@@ -9209,6 +9230,7 @@
           "name",
           "slug",
           "category",
+          "aliased_to",
           "lang_prefs",
           "n_instance"
         ],
@@ -9232,6 +9254,16 @@
           "category": {
             "$ref": "#/components/schemas/SongTagCategory"
           },
+          "aliased_to": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TagSongSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "lang_prefs": {
             "items": {
               "$ref": "#/components/schemas/TagLangPreferenceSchema"
@@ -9252,6 +9284,7 @@
           "name",
           "slug",
           "category",
+          "aliased_to",
           "lang_prefs",
           "children"
         ],

--- a/backend/otodb/api/tag.py
+++ b/backend/otodb/api/tag.py
@@ -124,6 +124,7 @@ class TagSongSchema(Schema):
 	name: str
 	slug: str
 	category: SongTagCategory
+	aliased_to: Optional['TagSongSchema']
 	lang_prefs: list[TagLangPreferenceSchema]
 
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -7,10 +7,11 @@ import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript-eslint';
-import { defineConfig } from 'eslint/config';
+import { defineConfig, globalIgnores } from 'eslint/config';
 const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
 
 export default defineConfig(
+	globalIgnores(['static/']),
 	includeIgnoreFile(gitignorePath),
 	js.configs.recommended,
 	...ts.configs.recommended,

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -50,6 +50,22 @@
 	);
 
 	let new_item: null | Work | Song = $state(null);
+	let field: { focus: () => void } | undefined = $state();
+
+	const add = (self: HTMLElement, v: Work | Song | null) => {
+		if (v && v.id !== this_id && !relations.some((r) => r.item.id === v.id)) {
+			self.dispatchEvent(new Event('change', { bubbles: true }));
+			relations.unshift({
+				selected: false,
+				tr: null,
+				swapped: false,
+				item: v,
+				relation: 0
+			});
+		}
+		new_item = null;
+		field?.focus();
+	};
 
 	let last_clicked_index: number | null = $state(null);
 	let last_entered_index: number | null = $state(null);
@@ -133,33 +149,12 @@
 	}}
 >
 	<input type="submit" class="float-right" />
-	<div class="grid w-fit grid-cols-2 gap-3">
+	<div class="w-fit">
 		{#if obj_type === 'work'}
-			<WorkField bind:value={new_item as Work} />
+			<WorkField bind:value={new_item as Work} oninput={add} bind:this={field} />
 		{:else if obj_type === 'song'}
-			<SongField bind:value={new_item as Song} />
+			<SongField bind:value={new_item as Song} oninput={add} bind:this={field} />
 		{/if}
-		<button
-			onclick={(e) => {
-				if (
-					new_item &&
-					new_item.id !== this_id &&
-					!relations.some((r) => r.item.id === new_item!.id)
-				) {
-					e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
-					relations.unshift({
-						selected: false,
-						tr: null,
-						swapped: false,
-						item: new_item,
-						relation: 0
-					});
-					new_item = null;
-				}
-			}}
-			type="button"
-			disabled={!new_item}>{m.swift_dry_gecko_boost()}</button
-		>
 	</div>
 	{#snippet batch_select()}
 		<select

--- a/frontend/src/lib/RelationEditor.svelte
+++ b/frontend/src/lib/RelationEditor.svelte
@@ -50,7 +50,7 @@
 	);
 
 	let new_item: null | Work | Song = $state(null);
-	let field: { focus: () => void } | undefined = $state();
+	let field: WorkField | SongField | null = null;
 
 	const add = (self: HTMLElement, v: Work | Song | null) => {
 		if (v && v.id !== this_id && !relations.some((r) => r.item.id === v.id)) {

--- a/frontend/src/lib/SongField.svelte
+++ b/frontend/src/lib/SongField.svelte
@@ -3,8 +3,15 @@
 	import { m } from '$lib/paraglide/messages';
 	import type { components } from '$lib/schema';
 	import { clickOutside, debounce } from '$lib/ui';
+	import { tick } from 'svelte';
 
 	let self: HTMLElement;
+	let search_input: HTMLInputElement | undefined = $state();
+
+	export async function focus() {
+		await tick();
+		search_input?.focus();
+	}
 
 	let input: string = $state('');
 	interface Props {
@@ -16,6 +23,37 @@
 
 	let suggestions: components['schemas']['SongSchema'][] = $state([]);
 	let locked_in = $state(false);
+	let selectedIndex = $state(0);
+
+	$effect(() => {
+		void suggestions;
+		selectedIndex = 0;
+	});
+
+	const selectSong = (v: (typeof suggestions)[number]) => {
+		value = v;
+		input = v.title;
+		suggestions = [];
+		locked_in = true;
+		if (oninput) oninput(self, v);
+	};
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		if (!suggestions.length) return;
+
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			selectedIndex = (selectedIndex + 1) % suggestions.length;
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			selectedIndex = selectedIndex <= 0 ? suggestions.length - 1 : selectedIndex - 1;
+		} else if (e.key === 'Enter') {
+			e.preventDefault();
+			selectSong(suggestions[selectedIndex]);
+		} else if (e.key === 'Escape') {
+			suggestions = [];
+		}
+	};
 
 	const search = async () => {
 		if (input === '') {
@@ -49,11 +87,19 @@
 				value = null;
 				locked_in = false;
 				if (oninput) oninput(self, null);
+				focus();
 			}}>{m.quick_happy_trout_amuse()}</button
 		>
 		<a target="_blank" href="/tag/{value?.work_tag}">{value?.title}</a>
 	{:else}
-		<input type="text" oninput={debounce(search)} disabled={locked_in} bind:value={input} />
+		<input
+			type="text"
+			oninput={debounce(search)}
+			onkeydown={handleKeyDown}
+			disabled={locked_in}
+			bind:value={input}
+			bind:this={search_input}
+		/>
 	{/if}
 	{#if suggestions.length}
 		<table
@@ -65,7 +111,10 @@
 		>
 			<tbody>
 				{#each suggestions as v, i (i)}
-					<tr class="w bg-otodb-bg-fainter hover:bg-otodb-bg-faint p-1">
+					<tr
+						class={['p-1', selectedIndex === i ? 'bg-otodb-bg-faint' : 'bg-otodb-bg-fainter']}
+						onmouseenter={() => (selectedIndex = i)}
+					>
 						<td
 							><a
 								class="cursor-pointer"
@@ -73,11 +122,7 @@
 								onclick={(e) => {
 									if (e.button !== 0) return;
 									e.preventDefault();
-									value = v;
-									input = v.title;
-									suggestions = [];
-									locked_in = true;
-									if (oninput) oninput(self, v);
+									selectSong(v);
 								}}>{v.title}</a
 							>
 						</td>

--- a/frontend/src/lib/SongField.svelte
+++ b/frontend/src/lib/SongField.svelte
@@ -6,7 +6,7 @@
 	import { tick } from 'svelte';
 
 	let self: HTMLElement;
-	let search_input: HTMLInputElement | undefined = $state();
+	let search_input: HTMLInputElement | null = null;
 
 	export async function focus() {
 		await tick();
@@ -14,14 +14,14 @@
 	}
 
 	let input: string = $state('');
+	type Song = components['schemas']['SongSchema'];
 	interface Props {
-		value: components['schemas']['SongSchema'] | null | undefined;
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-		oninput?: Function;
+		value: Song | null | undefined;
+		oninput?: (element: HTMLSpanElement, v: Song | null) => void;
 	}
 	let { value = $bindable(undefined), oninput = undefined, ...props }: Props = $props();
 
-	let suggestions: components['schemas']['SongSchema'][] = $state([]);
+	let suggestions: Song[] = $state([]);
 	let locked_in = $state(false);
 	let selectedIndex = $state(0);
 
@@ -30,7 +30,7 @@
 		selectedIndex = 0;
 	});
 
-	const selectSong = (v: (typeof suggestions)[number]) => {
+	const selectSong = (v: Song) => {
 		value = v;
 		input = v.title;
 		suggestions = [];

--- a/frontend/src/lib/TagField.svelte
+++ b/frontend/src/lib/TagField.svelte
@@ -3,7 +3,7 @@
 	import TagSuggestionResults from '$lib/TagSuggestionResults.svelte';
 	import { clickOutside, debounce } from '$lib/ui';
 	import { getTagDisplaySlug } from '$lib/ui.js';
-	import type { ComponentProps } from 'svelte';
+	import type { components } from './schema';
 
 	interface Props {
 		value: string;
@@ -12,7 +12,9 @@
 	}
 	let { value = $bindable(''), type, ...props }: Props = $props();
 
-	let suggestions: ComponentProps<typeof TagSuggestionResults>['suggestions'] = $state([]);
+	let suggestions:
+		| components['schemas']['TagWorkSearchResultSchema'][]
+		| components['schemas']['TagSongSearchResultSchema'][] = $state([]);
 
 	const search = async () => {
 		if (value === '') {

--- a/frontend/src/lib/TagSuggestionResults.svelte
+++ b/frontend/src/lib/TagSuggestionResults.svelte
@@ -1,31 +1,19 @@
 <script lang="ts">
 	import { WorkTagCategoryMap } from '$lib/enums/workTagCategory';
-	import type { WorkTagCategory } from '$lib/schema';
+	import type { components, SongTagCategory, WorkTagCategory } from '$lib/schema';
 
 	const showBaseTag = (
 		alias: { slug: string },
 		canonical: { lang_prefs: { slug: string }[] }
 	): boolean => !canonical.lang_prefs.some((p) => p.slug === alias.slug);
 
-	type SuggestionTag = {
-		id: string;
-		name: string;
-		slug: string;
-		category: number;
-		aliased_to?: null | {
-			id: string;
-			name: string;
-			slug: string;
-			category: number;
-			lang_prefs: { slug: string }[];
-		};
-		lang_prefs: { tag: string }[];
-		n_instance: number;
-	};
+	type Tag =
+		| components['schemas']['TagWorkSearchResultSchema']
+		| components['schemas']['TagSongSearchResultSchema'];
 
 	interface Props {
-		suggestions: SuggestionTag[];
-		onselect: (tag: any) => void;
+		suggestions: Tag[];
+		onselect: (tag: Tag) => void;
 		onclose?: () => void;
 		type: 'work' | 'song';
 		query?: string;
@@ -69,7 +57,7 @@
 		return result;
 	};
 
-	const getTagStyle = (category: WorkTagCategory) => {
+	const getTagStyle = (category: WorkTagCategory | SongTagCategory) => {
 		return type === 'work' && category !== 0 ? `color: ${WorkTagCategoryMap[category].color}` : '';
 	};
 </script>

--- a/frontend/src/lib/TagsField.svelte
+++ b/frontend/src/lib/TagsField.svelte
@@ -4,6 +4,7 @@
 	import TagSuggestionResults from '$lib/TagSuggestionResults.svelte';
 	import { clickOutside, debounce } from '$lib/ui';
 	import { getTagDisplaySlug } from '$lib/ui.js';
+	import type { components } from './schema';
 
 	interface Props {
 		value: string[];
@@ -14,7 +15,10 @@
 	let { value = $bindable([]), type, ...props }: Props = $props();
 
 	let textarea: HTMLTextAreaElement;
-	let suggestions = $state<any[]>([]);
+	let suggestions = $state<
+		| components['schemas']['TagWorkSearchResultSchema'][]
+		| components['schemas']['TagSongSearchResultSchema'][]
+	>([]);
 	let lastQuery = $state('');
 
 	const slug_re = /[\p{L}\p{N}_\-]/v;
@@ -73,7 +77,7 @@
 		];
 	};
 
-	const selectTag = (tag: any) => {
+	const selectTag = (tag: (typeof suggestions)[number]) => {
 		textarea.value = replaceWordAtPos(
 			textarea.value,
 			textarea.selectionStart,

--- a/frontend/src/lib/WorkField.svelte
+++ b/frontend/src/lib/WorkField.svelte
@@ -6,8 +6,15 @@
 	import { clickOutside, debounce } from '$lib/ui';
 	import { getDisplayText } from '$lib/ui.js';
 	import WorkThumbnail from '$lib/WorkThumbnail.svelte';
+	import { tick } from 'svelte';
 
 	let self: HTMLElement;
+	let search_input: HTMLInputElement | undefined = $state();
+
+	export async function focus() {
+		await tick();
+		search_input?.focus();
+	}
 
 	let input: string = $state('');
 	interface Props {
@@ -82,6 +89,7 @@
 		onkeydown={handleKeyDown}
 		disabled={locked_in}
 		bind:value={input}
+		bind:this={search_input}
 	/>
 	<input type="text" hidden value={value?.id ?? '-1'} {name} />
 	{#if locked_in}
@@ -91,6 +99,7 @@
 				value = null;
 				locked_in = false;
 				if (oninput) oninput(self, null);
+				focus();
 			}}>{m.quick_happy_trout_amuse()}</button
 		>
 		<a target="_blank" href="/work/{value?.id}"

--- a/frontend/src/lib/WorkField.svelte
+++ b/frontend/src/lib/WorkField.svelte
@@ -9,7 +9,7 @@
 	import { tick } from 'svelte';
 
 	let self: HTMLElement;
-	let search_input: HTMLInputElement | undefined = $state();
+	let search_input: HTMLInputElement | null = null;
 
 	export async function focus() {
 		await tick();
@@ -17,15 +17,15 @@
 	}
 
 	let input: string = $state('');
+	type Work = components['schemas']['ThinWorkSchema'];
 	interface Props {
-		value: components['schemas']['ThinWorkSchema'] | null | undefined;
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-		oninput?: Function;
+		value: Work | null | undefined;
+		oninput?: (element: HTMLSpanElement, v: Work | null) => void;
 		name?: string;
 	}
 	let { value = $bindable(undefined), oninput = undefined, name }: Props = $props();
 
-	let suggestions: components['schemas']['ThinWorkSchema'][] = $state([]);
+	let suggestions: Work[] = $state([]);
 	let locked_in = $state(false);
 	let selectedIndex = $state(0);
 
@@ -34,7 +34,7 @@
 		selectedIndex = 0;
 	});
 
-	const selectWork = (v: (typeof suggestions)[number]) => {
+	const selectWork = (v: Work) => {
 		value = v;
 		input = getDisplayText(v.title, '');
 		suggestions = [];

--- a/frontend/src/lib/dirty.ts
+++ b/frontend/src/lib/dirty.ts
@@ -35,10 +35,7 @@ export type Control = {
 
 export const dirtyEnhance = (
 	node: HTMLFormElement,
-	props?: {
-		form?: any;
-		custom_submit?: SubmitFunction;
-	} & (Control | { [K in keyof Control]?: never })
+	props?: { custom_submit?: SubmitFunction } & (Control | { [K in keyof Control]?: never })
 ) => {
 	if (props?.priority) node.dataset.priority = props.priority.toString();
 	node.addEventListener('change', () => {


### PR DESCRIPTION
- Add relation immediately on enter
  - Doesn't submit the form, just removes the need for the "New" button. I'm unsure whether or not this is done intentionally, but to me it feels wrong and prevents keying in a bunch of items in bulk (something that is helpful for song relations especially)
- Refocus to text input upon selection or "Change" button
- Mirror WorkField's keyboard controls in SongField