### PR TITLE
Proper tag capitalization in frontend when editing

### DIFF
--- a/frontend/src/lib/TagEditTable.svelte
+++ b/frontend/src/lib/TagEditTable.svelte
@@ -4,7 +4,6 @@
 	import { allCreatorRoles, creatorRole } from '$lib/enums/creatorRole';
 	import { WorkTagCategoryMap } from '$lib/enums/workTagCategory';
 	import { m } from '$lib/paraglide/messages.js';
-	import { getTagDisplaySlug } from '$lib/ui.js';
 	import type { ComponentProps } from 'svelte';
 	import { WorkTagCategory } from './schema';
 
@@ -77,11 +76,7 @@
 					<td><WorkTag {tag} /></td>
 					<td>
 						{#if WorkTagCategoryMap[tag.category].canSetAsSource}
-							<input
-								type="checkbox"
-								onclick={() => toggle_sample(getTagDisplaySlug(tag))}
-								checked={tag.sample}
-							/>
+							<input type="checkbox" onclick={() => toggle_sample(slug)} checked={tag.sample} />
 						{:else}{m.simple_less_marlin_enchant()}{/if}
 					</td>
 					<td>
@@ -92,7 +87,7 @@
 										class="hidden"
 										type="checkbox"
 										checked={tag.creator_roles?.includes(creatorRole[k].id) || false}
-										onchange={() => toggle_creator_role(getTagDisplaySlug(tag), creatorRole[k].id)}
+										onchange={() => toggle_creator_role(slug, creatorRole[k].id)}
 									/>{creatorRole[k].nameFn()}
 								</label>
 							{/each}

--- a/frontend/src/lib/TagField.svelte
+++ b/frontend/src/lib/TagField.svelte
@@ -2,7 +2,7 @@
 	import client from '$lib/api';
 	import TagSuggestionResults from '$lib/TagSuggestionResults.svelte';
 	import { clickOutside, debounce } from '$lib/ui';
-	import { getTagDisplaySlug } from '$lib/ui.js';
+	import { getTagDisplayToken } from '$lib/ui.js';
 	import type { ComponentProps } from 'svelte';
 
 	interface Props {
@@ -52,7 +52,7 @@
 			<TagSuggestionResults
 				{suggestions}
 				onselect={(t) => {
-					value = getTagDisplaySlug(t.aliased_to || t);
+					value = getTagDisplayToken(t.aliased_to || t);
 					suggestions = [];
 				}}
 				onclose={() => (suggestions = [])}

--- a/frontend/src/lib/TagsEditor.svelte
+++ b/frontend/src/lib/TagsEditor.svelte
@@ -4,7 +4,7 @@
 	import WorkTag from '$lib/WorkTag.svelte';
 	import { WorkTagCategoryMap } from '$lib/enums/workTagCategory';
 	import { m } from '$lib/paraglide/messages';
-	import { getTagDisplaySlug } from '$lib/ui.js';
+	import { getTagDisplayToken } from '$lib/ui.js';
 	import type { components } from '$lib/schema.js';
 	import type { ComponentProps } from 'svelte';
 
@@ -30,19 +30,19 @@
 
 	$effect(() => {
 		for (const t of sortedSuggestions) {
-			const slug = getTagDisplaySlug(t);
-			if (!cache[slug]) {
-				cache[slug] = { ...t, sample: false, creator_roles: null };
+			const token = getTagDisplayToken(t);
+			if (!cache[token]) {
+				cache[token] = { ...t, sample: false, creator_roles: null };
 			}
 		}
 	});
 
 	const toggleTag: ComponentProps<typeof WorkTag>['onclick'] = (tag) => {
-		const slug = getTagDisplaySlug(tag);
-		if (tags.includes(slug)) {
-			tags = tags.filter((t) => t !== slug);
+		const token = getTagDisplayToken(tag);
+		if (tags.includes(token)) {
+			tags = tags.filter((t) => t !== token);
 		} else {
-			tags = [...tags, slug];
+			tags = [...tags, token];
 		}
 	};
 </script>
@@ -51,7 +51,7 @@
 	<div class="text-otodb-content-fainter my-1 text-sm">{m.keen_mild_lark_point()}</div>
 	<div class="my-2 flex flex-wrap gap-1.5">
 		{#each sortedSuggestions as t (t.slug)}
-			<WorkTag tag={t} selected={tags.includes(getTagDisplaySlug(t))} onclick={toggleTag} />
+			<WorkTag tag={t} selected={tags.includes(getTagDisplayToken(t))} onclick={toggleTag} />
 		{/each}
 	</div>
 {/if}

--- a/frontend/src/lib/TagsField.svelte
+++ b/frontend/src/lib/TagsField.svelte
@@ -3,7 +3,7 @@
 	import { m } from '$lib/paraglide/messages';
 	import TagSuggestionResults from '$lib/TagSuggestionResults.svelte';
 	import { clickOutside, debounce } from '$lib/ui';
-	import { getTagDisplaySlug } from '$lib/ui.js';
+	import { getTagDisplayToken } from '$lib/ui.js';
 
 	interface Props {
 		value: string[];
@@ -77,7 +77,7 @@
 		textarea.value = replaceWordAtPos(
 			textarea.value,
 			textarea.selectionStart,
-			getTagDisplaySlug(tag.aliased_to || tag) + ' '
+			getTagDisplayToken(tag.aliased_to || tag) + ' '
 		);
 		suggestions = [];
 		updateValue();

--- a/frontend/src/lib/ui.ts
+++ b/frontend/src/lib/ui.ts
@@ -74,6 +74,18 @@ export const getTagDisplaySlug = (tag: {
 	lang_prefs: { lang: number; slug: string }[];
 }) => tag.lang_prefs.find(({ lang }) => lang === languages[getLocale()].id)?.slug ?? tag.slug;
 
+/* Matches backend's `clean_tag`; used for frontend display, slugified on the backend */
+export const getTagDisplayToken = (tag: {
+	name: string;
+	lang_prefs: { lang: number; tag: string }[];
+}) =>
+	getTagDisplayName(tag)
+		.normalize('NFKC')
+		.trim()
+		.replace(/\s+/gu, '_')
+		.replace(/[^\p{L}\p{N}_-]+/gu, '')
+		.replace(/^[-_]+|[-_]+$/g, '');
+
 export function getDisplayText(
 	value: string | null | undefined,
 	placeholder: string | undefined = undefined

--- a/frontend/src/routes/tag/[tag_slug]/+page.svelte
+++ b/frontend/src/routes/tag/[tag_slug]/+page.svelte
@@ -25,7 +25,7 @@
 		type components
 	} from '$lib/schema.js';
 	import { WorkTagCategoryMap } from '$lib/enums/workTagCategory.js';
-	import { getTagDisplayName, getTagDisplaySlug } from '$lib/ui.js';
+	import { getTagDisplayName, getTagDisplayToken } from '$lib/ui.js';
 
 	let { data } = $props();
 	let results = $derived(data.works!.items);
@@ -223,7 +223,7 @@
 
 <Section
 	title="{m.quiet_super_kangaroo_kiss({ tag: data.display_name })} ({data.works?.count})"
-	href="/work?tags={encodeURIComponent('^' + getTagDisplaySlug(data.tag))}"
+	href="/work?tags={encodeURIComponent('^' + getTagDisplayToken(data.tag))}"
 >
 	{#if results.length}
 		<div class="grid grid-cols-[repeat(auto-fill,minmax(192px,1fr))] gap-x-4 gap-y-4">

--- a/frontend/src/routes/tag/[tag_slug]/edit/+page.svelte
+++ b/frontend/src/routes/tag/[tag_slug]/edit/+page.svelte
@@ -25,18 +25,18 @@
 	} from '$lib/schema.js';
 	import { WorkTagCategoryMap } from '$lib/enums/workTagCategory.js';
 	import { enumValues } from '$lib/enums';
-	import { getTagDisplaySlug } from '$lib/ui.js';
+	import { getTagDisplayToken } from '$lib/ui.js';
 
 	let { data, form } = $props();
 
-	let parents = $state(form?.parent_slugs ?? data.parents.map(getTagDisplaySlug));
+	let parents = $state(form?.parent_slugs ?? data.parents.map(getTagDisplayToken));
 	let prev_n_parents = parents.length;
 	let primary = $state(
 		form?.primary ??
 			(data.details?.primary_parent
 				? (() => {
 						const parentTag = data.parents.find((t) => t.slug === data.details.primary_parent);
-						return parentTag ? parents.indexOf(getTagDisplaySlug(parentTag)) : -1;
+						return parentTag ? parents.indexOf(getTagDisplayToken(parentTag)) : -1;
 					})()
 				: -1)
 	);

--- a/frontend/src/routes/work/[work_id]/tags/+page.svelte
+++ b/frontend/src/routes/work/[work_id]/tags/+page.svelte
@@ -7,15 +7,15 @@
 	import GuidelineWarning from '$lib/GuidelineWarning.svelte';
 	import TagsEditor from '$lib/TagsEditor.svelte';
 	import type { components } from '$lib/schema.js';
-	import { getTagDisplaySlug, getMissingCategories } from '$lib/ui.js';
+	import { getTagDisplayToken, getMissingCategories } from '$lib/ui.js';
 	import Banner from '$lib/Banner.svelte';
 	import { WorkTagCategoryMap } from '$lib/enums/workTagCategory.js';
 
 	let { data } = $props();
 
-	let tags: string[] = $state(data.tags.map((t) => getTagDisplaySlug(t)));
+	let tags: string[] = $state(data.tags.map((t) => getTagDisplayToken(t)));
 	let cache: Record<string, components['schemas']['TagWorkInstanceThinSchema']> = $state(
-		Object.fromEntries(data.tags.map((t) => [getTagDisplaySlug(t), t]))
+		Object.fromEntries(data.tags.map((t) => [getTagDisplayToken(t), t]))
 	);
 
 	let missingCategories = $derived.by(() => getMissingCategories(Object.values(cache)));


### PR DESCRIPTION
This basically updates everywhere we use `getTagDisplaySlug` to instead display the tag using correct capitalization (related to #465) in a new `getTagDisplayToken` function. This is especially important for suggestions of new tags, since before it was lowercasing them, and I think gives the impression to new users that the capitalization can't be set upfront.