### PR TITLE
Prevent unbinding when only source on a work

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5951,7 +5951,8 @@
           10021,
           10022,
           10023,
-          10024
+          10024,
+          10025
         ],
         "title": "ErrorCode",
         "type": "integer",
@@ -5982,7 +5983,8 @@
           "Tag With Instances Merge Requires Editor",
           "Source Pending",
           "Captcha Failed",
-          "Max Thread Level"
+          "Max Thread Level",
+          "Only Work Source"
         ]
       },
       "LoginRequestSchema": {

--- a/backend/otodb/api/source.py
+++ b/backend/otodb/api/source.py
@@ -76,7 +76,7 @@ def unbind_source(request: AuthedHttpRequest, source_id: OtodbID):
 	if src.is_pending:
 		raise ApiError(400, ErrorCode.SOURCE_PENDING)
 	if src.media.worksource_set.count() == 1:
-		src.media.delete()
+		raise ApiError(400, ErrorCode.ONLY_WORK_SOURCE)
 	src.media = None
 	src.save()
 

--- a/backend/otodb/models/enums.py
+++ b/backend/otodb/models/enums.py
@@ -353,6 +353,7 @@ class ErrorCode(OtodbIntegerEnum):
 	SOURCE_PENDING = 10022
 	CAPTCHA_FAILED = 10023
 	MAX_THREAD_LEVEL = 10024
+	ONLY_WORK_SOURCE = 10025
 
 
 class Preferences(OtodbIntegerEnum):

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -363,6 +363,7 @@
 	"antsy_main_puffin_dust": "Cannot add sources to flagged works.",
 	"clean_civil_jellyfish_promise": "Cannot add sources to delisted works.",
 	"stout_brave_otter_reject": "Cannot unbind a pending source. Reject it instead.",
+	"giant_helpful_goose_explore": "Cannot unbind the only source of a work.",
 	"direct_fluffy_finch_believe": "Queue",
 	"awake_aware_quail_bake": "Moderation Event",
 	"cool_house_barbel_cheer": "Immediately resolve this work?",

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -14,6 +14,7 @@ const errorCodeMessages: Partial<Record<ErrorCode, (payload: ErrorPayload) => st
 	[ErrorCode.Source_Flagged]: () => m.antsy_main_puffin_dust(),
 	[ErrorCode.Source_Unapproved]: () => m.clean_civil_jellyfish_promise(),
 	[ErrorCode.Source_Pending]: () => m.stout_brave_otter_reject(),
+	[ErrorCode.Only_Work_Source]: () => m.giant_helpful_goose_explore(),
 	[ErrorCode.Self_Moderation]: () => m.fluffy_noble_gadfly_adapt(),
 	[ErrorCode.Login_Failed]: () => m.brave_stark_orca_note(),
 	[ErrorCode.Not_Logged_In]: () => m.major_keen_oryx_fall(),


### PR DESCRIPTION
Follow-up to #852, which was to fix a bug that caused the mod queue to be empty due to mod events having their work connection being removed, which surfaced due to editors having the ability to delete a work by unbinding all sources from it, even though deleting a work should be a moderator only operation.