### PR TITLE
Split lint and format responsibilities in frontend `package.json`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
 		"format": "oxfmt .",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"lint": "oxfmt --check . && eslint .",
+		"lint": "eslint .",
 		"storybook": "storybook dev -p 6006 --no-open",
 		"build-storybook": "storybook build",
 		"sync-schema": "openapi-typescript --enum",


### PR DESCRIPTION
## Summary
- The `lint` script in `frontend/package.json` ran both `oxfmt --check .` and `eslint .`, duplicating the responsibility of the dedicated `format` script.
- Change `lint` to run only `eslint .`, so `format` and `lint` each have a single, non-overlapping responsibility.

## Test plan
- [x] `bun run lint` runs only eslint
- [x] `bun run format` still runs oxfmt unaffected