### PR TITLE
Improve `<head>` metadata

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -11,6 +11,7 @@
         "@sentry/sveltekit": "^10.50.0",
         "@thisux/sveltednd": "^0.0.20",
         "mdast-util-find-and-replace": "^3.0.2",
+        "mdast-util-to-string": "^4.0.0",
         "mermaid": "^11.13.0",
         "openapi-fetch": "^0.15.2",
         "rehype-autolink-headings": "^7.1.0",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -453,5 +453,14 @@
 	"bold_keen_otter_vault": "Rollback to before this revision",
 	"tame_swift_heron_plead": "Rollback ALL revisions made by {username} to before {label}?",
 	"hazy_calm_otter_dream": "Plain Dark",
-	"misty_plain_finch_glow": "Plain Light"
+	"misty_plain_finch_glow": "Plain Light",
+	"tidy_calm_gecko_sail": "{title} by {creator}",
+	"zesty_brief_mole_chant": "Otomad/YTPMV - {details}",
+	"plain_witty_crane_hum": "An Otomad/YTPMV work on otoDB, the otomad/ytpmv database. View sources, tags, and related works.",
+	"brave_misty_lark_glow": "{name} – Otomad/YTPMV creator",
+	"sunny_civil_moth_drum": "{name} – Otomad/YTPMV song",
+	"witty_late_heron_bake": "{name} – Otomad/YTPMV source",
+	"quick_famous_otter_wave": "{name} – Otomad/YTPMV event",
+	"calm_super_finch_note": "{name} – Otomad/YTPMV tag",
+	"keen_vivid_snail_march": "Browse Otomad/YTPMV works tagged {name} on otoDB, the otomad/ytpmv database"
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -318,5 +318,14 @@
 	"bold_keen_otter_vault": "この変更より前にロールバック",
 	"tame_swift_heron_plead": "{username} のすべての変更を {label} より前にロールバックしますか？",
 	"hazy_calm_otter_dream": "無地（ダーク）",
-	"misty_plain_finch_glow": "無地（ライト）"
+	"misty_plain_finch_glow": "無地（ライト）",
+	"tidy_calm_gecko_sail": "{title}（{creator}）",
+	"zesty_brief_mole_chant": "音MAD作品 - {details}",
+	"plain_witty_crane_hum": "音MADデータベース「otoDB」に登録された音MAD作品。出典・タグ・関連作品を確認できます。",
+	"brave_misty_lark_glow": "{name} – 音MAD作者",
+	"sunny_civil_moth_drum": "{name} – 音MAD楽曲",
+	"witty_late_heron_bake": "{name} – 音MAD素材",
+	"quick_famous_otter_wave": "{name} – 音MADイベント",
+	"calm_super_finch_note": "{name} – 音MADタグ",
+	"keen_vivid_snail_march": "音MADデータベース「otoDB」で「{name}」タグの音MAD作品を閲覧"
 }

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -318,5 +318,14 @@
 	"bold_keen_otter_vault": "이 변경 이전으로 롤백",
 	"tame_swift_heron_plead": "{username}님의 모든 변경을 {label} 이전으로 롤백하시겠습니까?",
 	"hazy_calm_otter_dream": "무지 다크",
-	"misty_plain_finch_glow": "무지 라이트"
+	"misty_plain_finch_glow": "무지 라이트",
+	"tidy_calm_gecko_sail": "{title} – {creator}",
+	"zesty_brief_mole_chant": "음MAD 작품 - {details}",
+	"plain_witty_crane_hum": "음MAD 데이터베이스 otoDB에 등록된 음MAD 작품입니다. 출처, 태그, 관련 작품을 확인하세요.",
+	"brave_misty_lark_glow": "{name} – 음MAD 제작자",
+	"sunny_civil_moth_drum": "{name} – 음MAD 곡",
+	"witty_late_heron_bake": "{name} – 음MAD 소재",
+	"quick_famous_otter_wave": "{name} – 음MAD 이벤트",
+	"calm_super_finch_note": "{name} – 음MAD 태그",
+	"keen_vivid_snail_march": "음MAD 데이터베이스 otoDB에서 {name} 태그의 음MAD 작품을 둘러보세요"
 }

--- a/frontend/messages/zh-cn.json
+++ b/frontend/messages/zh-cn.json
@@ -319,5 +319,14 @@
 	"bold_keen_otter_vault": "回滚到此更改之前",
 	"tame_swift_heron_plead": "将 {username} 的所有更改回滚到 {label} 之前？",
 	"hazy_calm_otter_dream": "素色深色",
-	"misty_plain_finch_glow": "素色浅色"
+	"misty_plain_finch_glow": "素色浅色",
+	"tidy_calm_gecko_sail": "{title}（{creator}）",
+	"zesty_brief_mole_chant": "音MAD作品 - {details}",
+	"plain_witty_crane_hum": "音MAD数据库otoDB收录的音MAD作品。查看出处、标签和相关作品。",
+	"brave_misty_lark_glow": "{name} – 音MAD作者",
+	"sunny_civil_moth_drum": "{name} – 音MAD乐曲",
+	"witty_late_heron_bake": "{name} – 音MAD素材",
+	"quick_famous_otter_wave": "{name} – 音MAD活动",
+	"calm_super_finch_note": "{name} – 音MAD标签",
+	"keen_vivid_snail_march": "在音MAD数据库otoDB浏览标签为「{name}」的音MAD作品"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
 		"@sentry/sveltekit": "^10.50.0",
 		"@thisux/sveltednd": "^0.0.20",
 		"mdast-util-find-and-replace": "^3.0.2",
+		"mdast-util-to-string": "^4.0.0",
 		"mermaid": "^11.13.0",
 		"openapi-fetch": "^0.15.2",
 		"rehype-autolink-headings": "^7.1.0",

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -3,6 +3,7 @@ import { PostEntities } from '$lib/schema';
 import type { Root as HastRoot } from 'hast';
 import type { Parent, PhrasingContent, Root } from 'mdast';
 import { findAndReplace } from 'mdast-util-find-and-replace';
+import { toString as mdastToString } from 'mdast-util-to-string';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
@@ -234,6 +235,22 @@ const processor = unified()
  * Render markdown text to HTML with otoDB extensions.
  */
 export const renderMarkdown = (text: string) => String(processor.processSync(text));
+
+/**
+ * Reduce markdown to a plain-text excerpt for meta descriptions,
+ * truncated to `length` characters.
+ */
+export const markdownExcerpt = (text: string, length = 160): string | null => {
+	const plain = processor
+		.parse(text)
+		.children.map((node) => mdastToString(node))
+		.join(' ')
+		.replace(TAGWORK_RE, (_, slug, display) => display ?? slug)
+		.replace(/\s+/g, ' ')
+		.trim();
+	if (!plain) return null;
+	return plain.length <= length ? plain : plain.slice(0, length - 1) + '…';
+};
 
 /**
  * Extract unique @mentions from markdown source text.

--- a/frontend/src/routes/(auth)/login/+page.server.ts
+++ b/frontend/src/routes/(auth)/login/+page.server.ts
@@ -10,7 +10,7 @@ export const load: PageServerLoad = async ({ cookies, fetch, locals, url }) => {
 	const { response } = await client.GET('/api/auth/csrf', { fetch });
 	forwardCookies(cookies, response);
 
-	return { head: { title: m.inner_stale_anteater_walk() } };
+	return { head: { title: m.inner_stale_anteater_walk(), noindex: true } };
 };
 
 export const actions = {

--- a/frontend/src/routes/(auth)/register/+page.server.ts
+++ b/frontend/src/routes/(auth)/register/+page.server.ts
@@ -13,7 +13,7 @@ export const load: PageServerLoad = async ({ cookies, fetch, locals }) => {
 	const { response } = await client.GET('/api/auth/csrf', { fetch });
 	forwardCookies(cookies, response);
 	return {
-		head: { title: m.blue_whole_camel_type() },
+		head: { title: m.blue_whole_camel_type(), noindex: true },
 		inviteRequired: inviteRequired()
 	};
 };

--- a/frontend/src/routes/(auth)/reset_password/+page.server.ts
+++ b/frontend/src/routes/(auth)/reset_password/+page.server.ts
@@ -11,7 +11,10 @@ export const load: PageServerLoad = async ({ cookies, fetch, locals, url }) => {
 		const { response } = await client.GET('/api/auth/csrf', { fetch });
 		forwardCookies(cookies, response);
 	}
-	return { token, head: { title: m.true_tough_butterfly_sew() } };
+	return {
+		token,
+		head: { title: m.true_tough_butterfly_sew(), noindex: true }
+	};
 };
 
 export const actions = {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -110,6 +110,17 @@
 		})
 	);
 
+	// Canonical URLs strip the query string except for params a route declares
+	// as content-significant (e.g. pagination) via head.canonicalParams
+	const canonicalUrl = $derived.by(() => {
+		const query = ((page.data.head?.canonicalParams ?? []) as string[])
+			.map((key) => [key, page.url.searchParams.get(key)])
+			.filter(([, value]) => value)
+			.map(([key, value]) => `${key}=${encodeURIComponent(value!)}`)
+			.join('&');
+		return page.url.origin + page.url.pathname + (query ? `?${query}` : '');
+	});
+
 	const breadcrumbLd = $derived(
 		page.data.head?.breadcrumbs
 			? ldTag(
@@ -162,14 +173,16 @@
 	{#if page.data.head?.image}
 		<meta property="og:image" content={page.data.head.image} />
 		<meta name="twitter:image" content={page.data.head.image} />
+		<meta name="twitter:card" content="summary_large_image" />
 	{:else}
-		<meta property="og:image" content="https://otodb.net/thumb.png" />
-		<meta name="twitter:image" content="https://otodb.net/thumb.png" />
+		<meta name="twitter:card" content="summary" />
 	{/if}
 	<meta property="og:type" content={page.data.head?.ogType ?? 'website'} />
-	<link rel="canonical" href="{page.url.origin}{page.url.pathname}" />
-	<meta property="og:url" content="{page.url.origin}{page.url.pathname}" />
-	<meta name="twitter:card" content="summary_large_image" />
+	<link rel="canonical" href={canonicalUrl} />
+	<meta property="og:url" content={canonicalUrl} />
+	{#if page.data.head?.noindex}
+		<meta name="robots" content="noindex" />
+	{/if}
 	{#if page.data.head?.isExplicit}
 		<meta name="rating" content="adult" />
 	{/if}

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -39,7 +39,8 @@ export const load: PageServerLoad = async ({ fetch, setHeaders, locals }) => {
 			description: m.mild_loud_shad_enchant({
 				type: 'otoDB',
 				name: m.glad_born_mouse_taste()
-			})
+			}),
+			image: 'https://otodb.net/thumb.png'
 		}
 	};
 };

--- a/frontend/src/routes/list/+page.server.ts
+++ b/frontend/src/routes/list/+page.server.ts
@@ -8,7 +8,13 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 	const page = parseInt(url.searchParams.get('page') ?? '0', 10) || 1;
 	const { data } = await client.GET('/api/list/search', {
 		fetch,
-		params: { query: { query: query, limit: batch_size, offset: (page - 1) * batch_size } }
+		params: {
+			query: {
+				query: query,
+				limit: batch_size,
+				offset: (page - 1) * batch_size
+			}
+		}
 	});
 	return {
 		query: query,
@@ -18,7 +24,9 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 			title: m.mild_loud_shad_enchant({
 				type: m.mean_top_antelope_love(),
 				name: m.stale_loose_squid_cut()
-			})
+			}),
+			canonicalParams: ['page'],
+			noindex: !!query
 		}
 	};
 };

--- a/frontend/src/routes/list/[list_id]/+layout.server.ts
+++ b/frontend/src/routes/list/[list_id]/+layout.server.ts
@@ -1,5 +1,6 @@
 import client from '$lib/api.server';
 import type { LayoutServerLoad } from './$types';
+import { markdownExcerpt } from '$lib/markdown';
 import { m } from '$lib/paraglide/messages';
 
 export const load: LayoutServerLoad = async ({ fetch, params, locals }) => {
@@ -30,6 +31,7 @@ export const load: LayoutServerLoad = async ({ fetch, params, locals }) => {
 		],
 		head: {
 			title: data.name,
+			description: data.description ? markdownExcerpt(data.description) : null,
 			canonicalParams: ['page'],
 			breadcrumbs: [
 				{ name: m.fine_late_chicken_quiz(), url: '/' },

--- a/frontend/src/routes/list/[list_id]/+layout.server.ts
+++ b/frontend/src/routes/list/[list_id]/+layout.server.ts
@@ -20,11 +20,17 @@ export const load: LayoutServerLoad = async ({ fetch, params, locals }) => {
 				title: m.stale_loose_squid_cut() + ' ' + params.list_id
 			},
 			...(locals.user && locals.user.user_id === data.author.id
-				? [{ pathname: `list/${params.list_id}/edit`, title: m.minor_crisp_cobra_list() }]
+				? [
+						{
+							pathname: `list/${params.list_id}/edit`,
+							title: m.minor_crisp_cobra_list()
+						}
+					]
 				: [])
 		],
 		head: {
 			title: data.name,
+			canonicalParams: ['page'],
 			breadcrumbs: [
 				{ name: m.fine_late_chicken_quiz(), url: '/' },
 				{ name: m.stale_loose_squid_cut(), url: '/list' },

--- a/frontend/src/routes/page.stories.ts
+++ b/frontend/src/routes/page.stories.ts
@@ -123,7 +123,8 @@ const baseData = {
 		description: m.mild_loud_shad_enchant({
 			type: 'otoDB',
 			name: m.glad_born_mouse_taste()
-		})
+		}),
+		image: 'https://otodb.net/thumb.png'
 	}
 };
 

--- a/frontend/src/routes/settings/+page.server.ts
+++ b/frontend/src/routes/settings/+page.server.ts
@@ -1,0 +1,6 @@
+import { m } from '$lib/paraglide/messages';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = () => ({
+	head: { title: m.flat_small_kitten_race(), noindex: true }
+});

--- a/frontend/src/routes/settings/page.stories.ts
+++ b/frontend/src/routes/settings/page.stories.ts
@@ -1,12 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/sveltekit';
 import { http, HttpResponse } from 'msw';
 import type { ComponentProps } from 'svelte';
+import { m } from '$lib/paraglide/messages.js';
 import { Levels, ThemePref, VideoPlatformPref } from '$lib/schema';
 import Page from './+page.svelte';
 
 const handlers = [http.post('*/api/profile/prefs', () => new HttpResponse(null, { status: 200 }))];
 
 const stats = { works: 1234, tags: 567, songs: 89, lists: 42 };
+
+const head = { title: m.flat_small_kitten_race(), noindex: true };
 
 const loggedInUser = {
 	csrf: 'csrf-token',
@@ -25,7 +28,7 @@ const loggedInUser = {
 const meta = {
 	component: Page,
 	args: {
-		data: { user: null, stats }
+		data: { user: null, stats, head }
 	},
 	parameters: {
 		msw: { handlers }
@@ -39,7 +42,7 @@ export const Guest: Story = {};
 
 export const LoggedIn: Story = {
 	args: {
-		data: { user: loggedInUser, stats }
+		data: { user: loggedInUser, stats, head }
 	}
 };
 
@@ -54,7 +57,8 @@ export const LoggedInWithVideoPlatform: Story = {
 					PREFER_AUTHOR_UPLOAD: true
 				}
 			},
-			stats
+			stats,
+			head
 		}
 	}
 };

--- a/frontend/src/routes/song/+page.server.ts
+++ b/frontend/src/routes/song/+page.server.ts
@@ -38,7 +38,9 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 			title: m.mild_loud_shad_enchant({
 				type: m.mean_top_antelope_love(),
 				name: m.grand_nice_pony_belong()
-			})
+			}),
+			canonicalParams: ['tags', 'page'],
+			noindex: !!query
 		}
 	};
 };

--- a/frontend/src/routes/song_attribute/+page.server.ts
+++ b/frontend/src/routes/song_attribute/+page.server.ts
@@ -26,7 +26,8 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 			title: m.mild_loud_shad_enchant({
 				type: m.mean_top_antelope_love(),
 				name: m.dull_plain_angelfish_cuddle()
-			})
+			}),
+			noindex: !!query
 		}
 	};
 };

--- a/frontend/src/routes/tag/+page.server.ts
+++ b/frontend/src/routes/tag/+page.server.ts
@@ -72,7 +72,9 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 			title: m.mild_loud_shad_enchant({
 				type: m.mean_top_antelope_love(),
 				name: m.empty_legal_chicken_taste()
-			})
+			}),
+			canonicalParams: ['page'],
+			noindex: !!query
 		}
 	};
 };

--- a/frontend/src/routes/tag/[tag_slug]/+layout.server.ts
+++ b/frontend/src/routes/tag/[tag_slug]/+layout.server.ts
@@ -4,7 +4,14 @@ import { hasUserLevel } from '$lib/enums/userLevel';
 import { m } from '$lib/paraglide/messages.js';
 import { redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
-import { Levels } from '$lib/schema';
+import { Levels, WorkTagCategory } from '$lib/schema';
+
+const TITLE_BY_CATEGORY: Partial<Record<WorkTagCategory, (args: { name: string }) => string>> = {
+	[WorkTagCategory.Creator]: m.brave_misty_lark_glow,
+	[WorkTagCategory.Song]: m.sunny_civil_moth_drum,
+	[WorkTagCategory.Source]: m.witty_late_heron_bake,
+	[WorkTagCategory.Event]: m.quick_famous_otter_wave
+};
 
 export const load: LayoutServerLoad = async ({ params, fetch, locals, url }) => {
 	const { data } = await client.GET('/api/tag/tag', {
@@ -42,7 +49,12 @@ export const load: LayoutServerLoad = async ({ params, fetch, locals, url }) => 
 				title: m.empty_legal_chicken_taste() + ' ' + params.tag_slug
 			},
 			...(hasUserLevel(locals.user?.level, Levels.Member)
-				? [{ pathname: `tag/${params.tag_slug}/edit`, title: m.minor_crisp_cobra_list() }]
+				? [
+						{
+							pathname: `tag/${params.tag_slug}/edit`,
+							title: m.minor_crisp_cobra_list()
+						}
+					]
 				: []),
 			{
 				pathname: `tag/${params.tag_slug}/threads`,
@@ -81,7 +93,8 @@ export const load: LayoutServerLoad = async ({ params, fetch, locals, url }) => 
 		song_relations,
 		display_name,
 		head: {
-			title: display_name,
+			title: (TITLE_BY_CATEGORY[data.category] ?? m.calm_super_finch_note)({ name: display_name }),
+			description: m.keen_vivid_snail_march({ name: display_name }),
 			breadcrumbs: [
 				{ name: m.fine_late_chicken_quiz(), url: '/' },
 				{ name: m.empty_legal_chicken_taste(), url: '/tag' },

--- a/frontend/src/routes/tag/[tag_slug]/+page.server.ts
+++ b/frontend/src/routes/tag/[tag_slug]/+page.server.ts
@@ -1,4 +1,7 @@
 import client from '$lib/api.server';
+import { languages } from '$lib/enums/language';
+import { markdownExcerpt } from '$lib/markdown';
+import { getLocale } from '$lib/paraglide/runtime';
 import { ModelsWithComments } from '$lib/schema';
 import type { PageServerLoad } from './$types';
 
@@ -64,6 +67,11 @@ export const load: PageServerLoad = async ({ params, fetch, parent }) => {
 		})
 		.then((res) => res.data);
 
+	// Prefer tag's wiki over the generic tag description placeholder
+	const wikiEntry =
+		details.wiki_page.find((p) => p.lang === languages[getLocale()].id) ?? details.wiki_page[0];
+	const excerpt = wikiEntry ? markdownExcerpt(wikiEntry.page) : null;
+
 	return {
 		...details,
 		works,
@@ -72,6 +80,7 @@ export const load: PageServerLoad = async ({ params, fetch, parent }) => {
 		batch_size,
 		connections,
 		song_connections,
-		similar
+		similar,
+		head: excerpt ? { ...data.head, description: excerpt } : data.head
 	};
 };

--- a/frontend/src/routes/tag/[tag_slug]/edit/page.stories.ts
+++ b/frontend/src/routes/tag/[tag_slug]/edit/page.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/sveltekit';
 import { http, HttpResponse } from 'msw';
 import type { ComponentProps } from 'svelte';
+import { m } from '$lib/paraglide/messages.js';
 import {
 	LanguageTypes,
 	SongConnectionTypes,
@@ -72,6 +73,7 @@ const baseData = {
 	display_name: mediaTag.name,
 	head: {
 		title: mediaTag.name,
+		description: m.keen_vivid_snail_march({ name: mediaTag.name }),
 		breadcrumbs: [
 			{ name: 'Home', url: '/' },
 			{ name: 'Tags', url: '/tag' },
@@ -136,6 +138,7 @@ export const SongTag: Story = {
 			display_name: 'Example Song Tag',
 			head: {
 				title: 'Example Song Tag',
+				description: m.keen_vivid_snail_march({ name: 'Example Song Tag' }),
 				breadcrumbs: [
 					{ name: 'Home', url: '/' },
 					{ name: 'Tags', url: '/tag' },

--- a/frontend/src/routes/thread/+page.server.ts
+++ b/frontend/src/routes/thread/+page.server.ts
@@ -33,7 +33,9 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 			title: m.mild_loud_shad_enchant({
 				type: m.mean_top_antelope_love(),
 				name: m.just_salty_anaconda_nourish()
-			})
+			}),
+			canonicalParams: ['page'],
+			noindex: !!query
 		}
 	};
 };

--- a/frontend/src/routes/thread/[id]/+page.server.ts
+++ b/frontend/src/routes/thread/[id]/+page.server.ts
@@ -1,7 +1,7 @@
 import { env } from '$env/dynamic/private';
 import client, { rawClient } from '$lib/api.server';
 import { apiFail } from '$lib/errors';
-import { get_entity, parseMentions, renderMarkdown } from '$lib/markdown';
+import { get_entity, markdownExcerpt, parseMentions, renderMarkdown } from '$lib/markdown';
 import { m } from '$lib/paraglide/messages';
 import { fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
@@ -45,13 +45,18 @@ export const load: PageServerLoad = async ({ params, fetch, url }) => {
 		})
 	]);
 
+	const items = posts?.items ?? [];
+	const permalinkedPost =
+		(highlight_num !== null ? items.find((p) => p.num === highlight_num) : null) ?? items[0];
+
 	return {
 		thread,
 		batch_size,
-		posts: posts?.items ?? [],
+		posts: items,
 		post_count: posts?.count ?? 0,
 		head: {
 			title: thread?.title,
+			description: permalinkedPost ? markdownExcerpt(permalinkedPost.body) : null,
 			ogType: 'article',
 			breadcrumbs: [
 				{ name: m.fine_late_chicken_quiz(), url: '/' },

--- a/frontend/src/routes/thread/page.stories.ts
+++ b/frontend/src/routes/thread/page.stories.ts
@@ -13,7 +13,7 @@ const links = [
 const baseData = {
 	user: null,
 	stats: { works: 1234, tags: 567, songs: 89, lists: 42 },
-	head: { title: m.mean_top_antelope_love() },
+	head: { title: m.mean_top_antelope_love(), canonicalParams: ['page'], noindex: false },
 	links
 };
 

--- a/frontend/src/routes/wiki/[page_slug]/+layout.server.ts
+++ b/frontend/src/routes/wiki/[page_slug]/+layout.server.ts
@@ -1,6 +1,9 @@
 import client from '$lib/api.server';
+import { languages } from '$lib/enums/language';
 import { hasUserLevel } from '$lib/enums/userLevel';
+import { markdownExcerpt } from '$lib/markdown';
 import { m } from '$lib/paraglide/messages';
+import { getLocale } from '$lib/paraglide/runtime';
 import { Levels } from '$lib/schema';
 import type { LayoutServerLoad } from './$types';
 
@@ -13,11 +16,14 @@ export const load: LayoutServerLoad = async ({ params, fetch, locals }) => {
 
 	const canEdit = hasUserLevel(locals.user?.level, Levels.Mod);
 
+	const localized = wiki_page.find((p) => p.lang === languages[getLocale()].id) ?? wiki_page[0];
+
 	return {
 		page_slug: params.page_slug,
 		wiki_page,
 		head: {
-			title: wiki_page.find((p) => p.title)?.title ?? params.page_slug
+			title: wiki_page.find((p) => p.title)?.title ?? params.page_slug,
+			description: localized ? markdownExcerpt(localized.page) : null
 		},
 		menuLinks: [
 			{

--- a/frontend/src/routes/work/+page.server.ts
+++ b/frontend/src/routes/work/+page.server.ts
@@ -29,7 +29,9 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 			title: m.mild_loud_shad_enchant({
 				type: m.mean_top_antelope_love(),
 				name: m.grand_merry_fly_succeed()
-			})
+			}),
+			canonicalParams: ['tags', 'page'],
+			noindex: !!query
 		}
 	};
 };

--- a/frontend/src/routes/work/[work_id]/+layout.server.ts
+++ b/frontend/src/routes/work/[work_id]/+layout.server.ts
@@ -43,7 +43,7 @@ export const load: LayoutServerLoad = async ({ params, fetch, locals, url }) => 
 		);
 
 	// Collapse tag set along primary parenthood. For sources over the cap, we
-	// keep only the highest-level applied tags, while creators and 
+	// keep only the highest-level applied tags, while creators and
 	// songs keep only the lowest applied descendants.
 	const roots = (tags: WorkTag[]) => {
 		const ids = new Set(tags.map((tag) => tag.id));

--- a/frontend/src/routes/work/[work_id]/+layout.server.ts
+++ b/frontend/src/routes/work/[work_id]/+layout.server.ts
@@ -1,10 +1,14 @@
 import client from '$lib/api.server';
-import { getDisplayText } from '$lib/ui';
+import { getDisplayText, getTagDisplayName } from '$lib/ui';
 import { hasUserLevel } from '$lib/enums/userLevel';
+import { creatorRole } from '$lib/enums/creatorRole';
+import { WorkTagCategoryMap } from '$lib/enums/workTagCategory';
 import { m } from '$lib/paraglide/messages.js';
 import { redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
-import { Levels, Rating } from '$lib/schema';
+import { Levels, Rating, WorkTagCategory, type components } from '$lib/schema';
+
+type WorkTag = components['schemas']['TagWorkInstanceSchema'];
 
 export const load: LayoutServerLoad = async ({ params, fetch, locals, url }) => {
 	const { data } = await client.GET('/api/work/work', {
@@ -23,6 +27,67 @@ export const load: LayoutServerLoad = async ({ params, fetch, locals, url }) => 
 		);
 
 	const loggedOut = !hasUserLevel(locals.user?.level, Levels.Member);
+
+	const isSampled = (tag: WorkTag) => WorkTagCategoryMap[tag.category].canSetAsSource && tag.sample;
+	const isThanksOnly = (tag: WorkTag) =>
+		!!tag.creator_roles?.length &&
+		tag.creator_roles.every((role) => role === creatorRole.THANKS.id);
+
+	const tagsIn = (category: WorkTagCategory) =>
+		data.tags.filter((tag) =>
+			category === WorkTagCategory.Source
+				? tag.category === WorkTagCategory.Source || isSampled(tag)
+				: tag.category === category &&
+					!isSampled(tag) &&
+					(category !== WorkTagCategory.Creator || !isThanksOnly(tag))
+		);
+
+	// Collapse tag set along primary parenthood. For sources over the cap, we
+	// keep only the highest-level applied tags, while creators and 
+	// songs keep only the lowest applied descendants.
+	const roots = (tags: WorkTag[]) => {
+		const ids = new Set(tags.map((tag) => tag.id));
+		return tags.filter((tag) => !tag.primary_path.some((parent) => ids.has(parent.id)));
+	};
+	const leaves = (tags: WorkTag[]) => {
+		const ancestorIds = new Set(tags.flatMap((tag) => tag.primary_path.map((parent) => parent.id)));
+		return tags.filter((tag) => !ancestorIds.has(tag.id));
+	};
+
+	const creators = leaves(tagsIn(WorkTagCategory.Creator)).map(getTagDisplayName);
+	const title = getDisplayText(data.title);
+	const headTitle =
+		creators.length && creators.length <= 5
+			? m.tidy_calm_gecko_sail({ title, creator: creators.join(', ') })
+			: title;
+
+	// Categories with more collapsed tags than their cap are left out entirely,
+	// and songs are only shown alongside a creator or source.
+	const capped = (names: string[], max: number) =>
+		names.length && names.length <= max ? names : null;
+	const creatorDetail = capped(creators, 5);
+	const songDetail = capped(leaves(tagsIn(WorkTagCategory.Song)).map(getTagDisplayName), 2);
+	const sourceTags = tagsIn(WorkTagCategory.Source);
+	const sourceDetail = capped(
+		// If two sources, just show them all, otherwise only the highest-level sources
+		(sourceTags.length <= 2 ? sourceTags : roots(sourceTags))
+			.toSorted((a, b) => a.primary_path.length - b.primary_path.length)
+			.map(getTagDisplayName),
+		2
+	);
+
+	const entries: [WorkTagCategory, string[] | null][] = [
+		[WorkTagCategory.Creator, creatorDetail],
+		[WorkTagCategory.Song, creatorDetail || sourceDetail ? songDetail : null],
+		[WorkTagCategory.Source, sourceDetail]
+	];
+	const details = entries
+		.filter((entry): entry is [WorkTagCategory, string[]] => !!entry[1])
+		.map(([category, names]) => `${WorkTagCategoryMap[category].nameFn()}: ${names.join(', ')}`)
+		.join(' · ');
+	const headDescription = details
+		? m.zesty_brief_mole_chant({ details })
+		: m.plain_witty_crane_hum();
 
 	return {
 		links: [
@@ -48,7 +113,12 @@ export const load: LayoutServerLoad = async ({ params, fetch, locals, url }) => 
 				: []),
 			...(loggedOut
 				? []
-				: [{ pathname: `work/${params.work_id}/edit`, title: m.minor_crisp_cobra_list() }]),
+				: [
+						{
+							pathname: `work/${params.work_id}/edit`,
+							title: m.minor_crisp_cobra_list()
+						}
+					]),
 			{
 				pathname: `work/${params.work_id}/threads`,
 				title: m.big_tiny_kitten_devour()
@@ -64,13 +134,17 @@ export const load: LayoutServerLoad = async ({ params, fetch, locals, url }) => 
 		],
 		...data,
 		head: {
-			title: getDisplayText(data.title),
+			title: headTitle,
+			description: headDescription,
 			image: data.rating <= 1 ? data.thumbnail : null,
 			isExplicit: data.rating === Rating.Explicit,
 			breadcrumbs: [
 				{ name: m.fine_late_chicken_quiz(), url: '/' },
 				{ name: m.grand_merry_fly_succeed(), url: '/work' },
-				{ name: getDisplayText(data.title), url: `/work/${params.work_id}` }
+				{
+					name: getDisplayText(data.title),
+					url: `/work/${params.work_id}`
+				}
 			]
 		}
 	};


### PR DESCRIPTION
Doing this to hopefully improve SEO. It has occurred to me we really don't promote anywhere in the `<head>` currently that the content on the page relates to 音MAD/YTPMV, so this now explicitly does that everywhere.

Also closes #461

