### PR TITLE
Colour video info as async and propagate

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -49,10 +49,10 @@ ENV OTODB_HASH=${OTODB_HASH} \
     PATH="/app/.venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    GRANIAN_INTERFACE=wsgi \
+    GRANIAN_INTERFACE=asginl \
     GRANIAN_HOST=0.0.0.0 \
     GRANIAN_PORT=8000 \
     GRANIAN_WORKERS=4
 
 EXPOSE 8000
-CMD ["sh", "-c", "cp -r static/. /srv/static/ && python manage.py migrate && exec granian project.wsgi:application"]
+CMD ["sh", "-c", "cp -r static/. /srv/static/ && python manage.py migrate && exec granian project.asgi:application"]

--- a/backend/otodb/api/auth.py
+++ b/backend/otodb/api/auth.py
@@ -51,7 +51,7 @@ def verify_turnstile(request: HttpRequest, token: str | None, action: str) -> No
 		raise ApiError(400, ErrorCode.CAPTCHA_FAILED)
 	data = {'secret': secret, 'response': token}
 	# REMOTE_ADDR is resolved to the real client IP by Granian's proxy-header wrapper
-	# (see project/asgi/wsgi.py + OTODB_TRUSTED_PROXY_HOSTS)
+	# (see project/[asgi/wsgi].py + OTODB_TRUSTED_PROXY_HOSTS)
 	remoteip = request.META.get('REMOTE_ADDR')
 	if remoteip:
 		data['remoteip'] = remoteip

--- a/backend/otodb/api/auth.py
+++ b/backend/otodb/api/auth.py
@@ -51,7 +51,7 @@ def verify_turnstile(request: HttpRequest, token: str | None, action: str) -> No
 		raise ApiError(400, ErrorCode.CAPTCHA_FAILED)
 	data = {'secret': secret, 'response': token}
 	# REMOTE_ADDR is resolved to the real client IP by Granian's proxy-header wrapper
-	# (see project/wsgi.py + OTODB_TRUSTED_PROXY_HOSTS)
+	# (see project/asgi/wsgi.py + OTODB_TRUSTED_PROXY_HOSTS)
 	remoteip = request.META.get('REMOTE_ADDR')
 	if remoteip:
 		data['remoteip'] = remoteip

--- a/backend/otodb/api/common.py
+++ b/backend/otodb/api/common.py
@@ -309,11 +309,7 @@ class ListSchema(ModelSchema):
 		return value.upstream
 
 
-def _default_after_passthrough(ret, request, *args, **kwargs):
-	return ret
-
-
-def make_decorator(before, after=_default_after_passthrough):
+def make_decorator(before, after=None):
 	def universal_decorator(func):
 		if inspect.iscoroutinefunction(func):
 
@@ -321,7 +317,7 @@ def make_decorator(before, after=_default_after_passthrough):
 			async def async_wrapper(request, *args, **kwargs):
 				request, args, kwargs = before(request, *args, **kwargs)
 				ret = await func(request, *args, **kwargs)
-				if after is _default_after_passthrough:
+				if after is None:
 					return ret
 				return await sync_to_async(after)(ret, request, *args, **kwargs)
 
@@ -331,7 +327,10 @@ def make_decorator(before, after=_default_after_passthrough):
 			@wraps(func)
 			def sync_wrapper(request, *args, **kwargs):
 				request, args, kwargs = before(request, *args, **kwargs)
-				return after(func(request, *args, **kwargs), request, *args, **kwargs)
+				ret = func(request, *args, **kwargs)
+				if after is None:
+					return ret
+				return after(ret, request, *args, **kwargs)
 
 			return sync_wrapper
 

--- a/backend/otodb/api/common.py
+++ b/backend/otodb/api/common.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 import operator
 import re
 from abc import abstractmethod
@@ -8,6 +8,7 @@ from functools import lru_cache, reduce, wraps
 from typing import Annotated, Any, Callable, NamedTuple, Optional, Self
 
 import lark
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Exists, F, OuterRef, Q, Value
@@ -307,21 +308,34 @@ class ListSchema(ModelSchema):
 	def upstream_str(cls, value) -> str:
 		return value.upstream
 
-def make_decorator(before, after=lambda x: x):
+
+def _default_after_passthrough(ret, request, *args, **kwargs):
+	return ret
+
+
+def make_decorator(before, after=_default_after_passthrough):
 	def universal_decorator(func):
-		if asyncio.iscoroutinefunction(func):
+		if inspect.iscoroutinefunction(func):
+
 			@wraps(func)
 			async def async_wrapper(request, *args, **kwargs):
 				request, args, kwargs = before(request, *args, **kwargs)
-				return after(await func(request, *args, **kwargs))
+				return await sync_to_async(after)(
+					await func(request, *args, **kwargs), request, *args, **kwargs
+				)
+
 			return async_wrapper
 		else:
+
 			@wraps(func)
 			def sync_wrapper(request, *args, **kwargs):
 				request, args, kwargs = before(request, *args, **kwargs)
-				return after(func(request, *args, **kwargs))
+				return after(func(request, *args, **kwargs), request, *args, **kwargs)
+
 			return sync_wrapper
+
 	return universal_decorator
+
 
 def perm_decorator_ctor(uf):
 	def before(request, *args, **kwargs):
@@ -617,23 +631,23 @@ def _commit_pending_revision(cache, request):
 	)
 
 
-def track_revision(f):
-	@wraps(f)
-	def wrapper(request, *args, **kwargs):
-		cache = get_request_cache()
-		cache.add(
-			'rev', {}
-		)  # key: (ContentType.pk, pk, field as str), value: (entity_pks, str)
-		cache.add('rev_del', [])  # list of (ContentType.pk, pk, ...entity_pks)
-		cache.add('rev_rst', {})
-		cache.add('rev_msg', '')
+def _track_revision_before(request, *args, **kwargs):
+	cache = get_request_cache()
+	cache.add(
+		'rev', {}
+	)  # key: (ContentType.pk, pk, field as str), value: (entity_pks, str)
+	cache.add('rev_del', [])  # list of (ContentType.pk, pk, ...entity_pks)
+	cache.add('rev_rst', {})
+	cache.add('rev_msg', '')
+	return request, args, kwargs
 
-		ret = f(request, *args, **kwargs)
 
-		_commit_pending_revision(cache, request)
-		return ret
+def _track_revision_after(ret, request, *args, **kwargs):
+	_commit_pending_revision(get_request_cache(), request)
+	return ret
 
-	return wrapper
+
+track_revision = make_decorator(_track_revision_before, _track_revision_after)
 
 
 def add_revision_message(message: str):
@@ -678,6 +692,7 @@ def revision(
 
 def with_revision_route(route: Route):
 	"""Decorator to set the revision route for a API endpoint."""
+
 	def before(request, *args, **kwargs):
 		cache = get_request_cache()
 		cache.set('rev_route', route.value)

--- a/backend/otodb/api/common.py
+++ b/backend/otodb/api/common.py
@@ -320,9 +320,10 @@ def make_decorator(before, after=_default_after_passthrough):
 			@wraps(func)
 			async def async_wrapper(request, *args, **kwargs):
 				request, args, kwargs = before(request, *args, **kwargs)
-				return await sync_to_async(after)(
-					await func(request, *args, **kwargs), request, *args, **kwargs
-				)
+				ret = await func(request, *args, **kwargs)
+				if after is _default_after_passthrough:
+					return ret
+				return await sync_to_async(after)(ret, request, *args, **kwargs)
 
 			return async_wrapper
 		else:

--- a/backend/otodb/api/common.py
+++ b/backend/otodb/api/common.py
@@ -1,3 +1,4 @@
+import asyncio
 import operator
 import re
 from abc import abstractmethod
@@ -306,19 +307,30 @@ class ListSchema(ModelSchema):
 	def upstream_str(cls, value) -> str:
 		return value.upstream
 
+def make_decorator(before, after=lambda x: x):
+	def universal_decorator(func):
+		if asyncio.iscoroutinefunction(func):
+			@wraps(func)
+			async def async_wrapper(request, *args, **kwargs):
+				request, args, kwargs = before(request, *args, **kwargs)
+				return after(await func(request, *args, **kwargs))
+			return async_wrapper
+		else:
+			@wraps(func)
+			def sync_wrapper(request, *args, **kwargs):
+				request, args, kwargs = before(request, *args, **kwargs)
+				return after(func(request, *args, **kwargs))
+			return sync_wrapper
+	return universal_decorator
 
 def perm_decorator_ctor(uf):
-	def decorator(f):
-		@wraps(f)
-		def wrapper(request, *args, **kwargs):
-			if uf(request.user):
-				return f(request, *args, **kwargs)
-			else:
-				raise HttpError(403, 'Forbidden')
+	def before(request, *args, **kwargs):
+		if uf(request.user):
+			return request, args, kwargs
+		else:
+			raise HttpError(403, 'Forbidden')
 
-		return wrapper
-
-	return decorator
+	return make_decorator(before)
 
 
 user_is_trusted = perm_decorator_ctor(
@@ -666,17 +678,12 @@ def revision(
 
 def with_revision_route(route: Route):
 	"""Decorator to set the revision route for a API endpoint."""
+	def before(request, *args, **kwargs):
+		cache = get_request_cache()
+		cache.set('rev_route', route.value)
+		return request, args, kwargs
 
-	def decorator(f):
-		@wraps(f)
-		def wrapper(request, *args, **kwargs):
-			cache = get_request_cache()
-			cache.set('rev_route', route.value)
-			return f(request, *args, **kwargs)
-
-		return wrapper
-
-	return decorator
+	return make_decorator(before)
 
 
 class RouterWithRevision(Router):

--- a/backend/otodb/api/list.py
+++ b/backend/otodb/api/list.py
@@ -1,10 +1,11 @@
 import asyncio
 from typing import List
 
+from asgiref.sync import sync_to_async
 from django.db import transaction
 from django.db.models import Q
 from django.http import HttpRequest
-from django.shortcuts import get_object_or_404
+from django.shortcuts import aget_object_or_404, get_object_or_404
 from ninja import ModelSchema, Router, Schema
 from ninja.errors import HttpError
 from ninja.pagination import paginate
@@ -147,7 +148,6 @@ def delete(request: HttpRequest, list_id: OtodbID):
 	return
 
 
-@transaction.atomic
 def import_ext_into_pool(entries, infos, list_: Pool, user):
 	old_entries = list_.poolitem_set.values_list('work__id', flat=True)
 
@@ -184,25 +184,34 @@ def import_ext_into_pool(entries, infos, list_: Pool, user):
 @user_is_editor
 @track_revision
 async def import_ext(request: HttpRequest, url: str):
-	info = playlist_info(url)
-	list_ = Pool.objects.create(
-		name=info['title'], description=info['description'], author=request.user
-	)
-	PoolUpstream.objects.create(pool=list_, upstream=url)
-
+	info = await playlist_info(url)
 	infos = await asyncio.gather(*[video_info(v) for v in info['entries']])
-	import_ext_into_pool(info['entries'], infos, list_, request.user)
 
-	return list_.id
+	@transaction.atomic
+	def make_pool():
+		list_ = Pool.objects.create(
+			name=info['title'], description=info['description'], author=request.user
+		)
+		PoolUpstream.objects.create(pool=list_, upstream=url)
+		import_ext_into_pool(info['entries'], infos, list_, request.user)
+		return list_.id
+
+	list_id = await sync_to_async(make_pool)()
+
+	return list_id
 
 
 @list_router.post('pull_upstream', auth=django_auth)
 async def pull_upstream(request: HttpRequest, list_id: OtodbID):
-	lst = get_object_or_404(Pool, id=list_id)
+	lst = await aget_object_or_404(
+		Pool.objects.select_related('poolupstream'), id=list_id
+	)
 	if lst.author != request.user:
 		raise HttpError(403, 'Forbidden')
 
-	info = playlist_info(lst.poolupstream.upstream)
+	info = await playlist_info(lst.poolupstream.upstream)
 
 	infos = await asyncio.gather(*[video_info(v) for v in info['entries']])
-	import_ext_into_pool(info['entries'], infos, lst, request.user)
+	await sync_to_async(transaction.atomic(import_ext_into_pool))(
+		info['entries'], infos, lst, request.user
+	)

--- a/backend/otodb/api/list.py
+++ b/backend/otodb/api/list.py
@@ -149,7 +149,7 @@ def delete(request: HttpRequest, list_id: OtodbID):
 
 
 def import_ext_into_pool(entries, infos, list_: Pool, user):
-	old_entries = list_.poolitem_set.values_list('work__id', flat=True)
+	old_entries = set(list_.poolitem_set.values_list('work__id', flat=True))
 
 	pool_items = []
 	for i, (vid_info, full_info) in enumerate(list(infos)):
@@ -164,6 +164,10 @@ def import_ext_into_pool(entries, infos, list_: Pool, user):
 			user=user,
 			is_reupload=False,
 		)
+
+		if src is None:
+			list_.description += f'\nFailed to fetch {entries[i]}'
+			continue
 
 		if src.media is not None:
 			# Source already has a work, add to pool if not already there
@@ -206,7 +210,7 @@ async def pull_upstream(request: HttpRequest, list_id: OtodbID):
 	lst = await aget_object_or_404(
 		Pool.objects.select_related('poolupstream'), id=list_id
 	)
-	if lst.author != request.user:
+	if lst.author_id != request.user.id:
 		raise HttpError(403, 'Forbidden')
 
 	info = await playlist_info(lst.poolupstream.upstream)

--- a/backend/otodb/api/list.py
+++ b/backend/otodb/api/list.py
@@ -149,12 +149,13 @@ def delete(request: HttpRequest, list_id: OtodbID):
 
 
 def import_ext_into_pool(entries, infos, list_: Pool, user):
-	old_entries = set(list_.poolitem_set.values_list('work__id', flat=True))
+	# set() instead of .distinct() because list has not yet been written to the DB
+	existing_work_ids = set(list_.poolitem_set.values_list('work__id', flat=True))
 
-	pool_items = []
-	for i, (vid_info, full_info) in enumerate(list(infos)):
+	new_works = {}
+	for entry, (vid_info, full_info) in zip(entries, infos):
 		if vid_info is None:
-			list_.description += f'\nFailed to fetch {entries[i]}'
+			list_.description += f'\nFailed to fetch {entry}'
 			continue
 
 		src = WorkSource.from_url(
@@ -166,20 +167,20 @@ def import_ext_into_pool(entries, infos, list_: Pool, user):
 		)
 
 		if src is None:
-			list_.description += f'\nFailed to fetch {entries[i]}'
+			list_.description += f'\nFailed to fetch {entry}'
 			continue
 
-		if src.media is not None:
-			# Source already has a work, add to pool if not already there
-			if src.media.id not in old_entries:
-				pool_items.append(PoolItem(work=src.media, description='', pool=list_))
-				old_entries.add(src.media.id)
-		else:
+		if src.media is None:
 			# No work yet - add to pending for user review
 			list_.pending_items.add(src)
+		elif src.media.pk not in existing_work_ids:
+			# Source already has a work - add to pool if not already there
+			new_works[src.media.pk] = src.media
 
 	list_.save()
-	PoolItem.objects.bulk_create(pool_items)
+	PoolItem.objects.bulk_create(
+		[PoolItem(work=work, description='', pool=list_) for work in new_works.values()]
+	)
 
 
 @list_router.post(

--- a/backend/otodb/api/list.py
+++ b/backend/otodb/api/list.py
@@ -1,6 +1,4 @@
-import multiprocessing
-import sys
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+import asyncio
 from typing import List
 
 from django.db import transaction
@@ -149,30 +147,22 @@ def delete(request: HttpRequest, list_id: OtodbID):
 	return
 
 
-def import_ext_into_pool(info, list_: Pool, user):
-	if sys.platform == 'win32':
-		with ThreadPoolExecutor() as executor:
-			infos = list(executor.map(video_info, info['entries']))
-	else:
-		with ProcessPoolExecutor(
-			mp_context=multiprocessing.get_context('fork')
-		) as executor:
-			infos = list(executor.map(video_info, info['entries']))
-
+@transaction.atomic
+def import_ext_into_pool(entries, infos, list_: Pool, user):
 	old_entries = list_.poolitem_set.values_list('work__id', flat=True)
 
 	pool_items = []
 	for i, (vid_info, full_info) in enumerate(list(infos)):
 		if vid_info is None:
-			list_.description += f'\nFailed to fetch {info["entries"][i]}'
+			list_.description += f'\nFailed to fetch {entries[i]}'
 			continue
 
-		src, _ = WorkSource.from_url(
+		src = WorkSource.from_url(
 			vid_info['url'],
-			user=user,
-			is_reupload=False,
 			info=vid_info,
 			full_info=full_info,
+			user=user,
+			is_reupload=False,
 		)
 
 		if src.media is not None:
@@ -192,25 +182,27 @@ def import_ext_into_pool(info, list_: Pool, user):
 	'import', auth=django_auth, response=OtodbID, throttle=[AuthRateThrottle('3/30m')]
 )
 @user_is_editor
-@transaction.atomic
 @track_revision
-def import_ext(request: HttpRequest, url: str):
+async def import_ext(request: HttpRequest, url: str):
 	info = playlist_info(url)
 	list_ = Pool.objects.create(
 		name=info['title'], description=info['description'], author=request.user
 	)
 	PoolUpstream.objects.create(pool=list_, upstream=url)
 
-	import_ext_into_pool(info, list_, request.user)
+	infos = await asyncio.gather(*[video_info(v) for v in info['entries']])
+	import_ext_into_pool(info['entries'], infos, list_, request.user)
 
 	return list_.id
 
 
 @list_router.post('pull_upstream', auth=django_auth)
-def pull_upstream(request: HttpRequest, list_id: OtodbID):
+async def pull_upstream(request: HttpRequest, list_id: OtodbID):
 	lst = get_object_or_404(Pool, id=list_id)
 	if lst.author != request.user:
 		raise HttpError(403, 'Forbidden')
 
 	info = playlist_info(lst.poolupstream.upstream)
-	import_ext_into_pool(info, lst, request.user)
+
+	infos = await asyncio.gather(*[video_info(v) for v in info['entries']])
+	import_ext_into_pool(info['entries'], infos, lst, request.user)

--- a/backend/otodb/api/source.py
+++ b/backend/otodb/api/source.py
@@ -5,7 +5,7 @@ from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
-from django.shortcuts import get_object_or_404
+from django.shortcuts import aget_object_or_404, get_object_or_404
 from ninja import Schema
 from ninja.pagination import paginate
 from ninja.security import django_auth
@@ -105,8 +105,9 @@ def source_origin(request: AuthedHttpRequest, source_id: OtodbID, status: WorkOr
 @user_is_editor
 @with_revision_route(Route.WORKSOURCE_REFRESH)
 async def refresh_source(request: AuthedHttpRequest, source_id: OtodbID):
-	src: WorkSource = get_object_or_404(WorkSource.objects, id=source_id)
-	await src.refresh()
+	src: WorkSource = await aget_object_or_404(WorkSource.objects, id=source_id)
+	info, full_info = await video_info(src.url)
+	await sync_to_async(src.refresh)(info, full_info)
 	return
 
 

--- a/backend/otodb/api/source.py
+++ b/backend/otodb/api/source.py
@@ -1,6 +1,7 @@
 from datetime import date
 from typing import Annotated
 
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
@@ -11,7 +12,7 @@ from ninja.security import django_auth
 from pydantic import StringConstraints
 
 from otodb.account.models import Account
-from otodb.common import process_video_info, slugify_tag
+from otodb.common import process_video_info, slugify_tag, video_info
 from otodb.models import (
 	MediaWork,
 	ModerationEvent,
@@ -103,9 +104,9 @@ def source_origin(request: AuthedHttpRequest, source_id: OtodbID, status: WorkOr
 @source_router.post('refresh', auth=django_auth)
 @user_is_editor
 @with_revision_route(Route.WORKSOURCE_REFRESH)
-def refresh_source(request: AuthedHttpRequest, source_id: OtodbID):
+async def refresh_source(request: AuthedHttpRequest, source_id: OtodbID):
 	src: WorkSource = get_object_or_404(WorkSource.objects, id=source_id)
-	src.refresh()
+	await src.refresh()
 	return
 
 
@@ -146,9 +147,8 @@ def update_source(
 	response={200: SourceCreationResponse, 400: Error},
 )
 @user_is_trusted
-@transaction.atomic
 @with_revision_route(Route.WORKSOURCE_CREATE)
-def new_source_from_url(
+async def new_source_from_url(
 	request: AuthedHttpRequest,
 	url: Annotated[str, StringConstraints(strip_whitespace=True)],
 	is_reupload: bool,
@@ -167,44 +167,56 @@ def new_source_from_url(
 		raise ApiError(403, ErrorCode.EDITOR_ONLY)
 
 	metadata_dict = metadata.dict() if metadata else None
-	src, info = WorkSource.from_url(
-		url, user=request.user, is_reupload=is_reupload, metadata=metadata_dict
-	)
 
-	if src is None:
-		raise ApiError(400, ErrorCode.BAD_URL)
+	info, full_info = await video_info(url, expected_unavailable=metadata is not None)
 
-	src = WorkSource.objects.select_for_update(of=('self',)).get(pk=src.pk)
-
-	# Source already has a work -> redirect
-	if src.media:
-		return {'work_id': src.media.pk}
-
-	# work_id provided -> bind source to existing work
-	if work_id:
-		work = get_object_or_404(
-			MediaWork.objects.filter(moved_to__isnull=True), id=work_id
+	@transaction.atomic
+	def make_source():
+		src = WorkSource.from_url(
+			url,
+			info=info,
+			full_info=full_info,
+			user=request.user,
+			is_reupload=is_reupload,
+			metadata=metadata_dict,
 		)
-		if work.status == Status.DELISTED:
-			raise ApiError(400, ErrorCode.SOURCE_UNAPPROVED)
-		if work.moderation_events.filter(
-			event_type=ModerationEventType.FLAG, status=FlagStatus.PENDING
-		).exists():
-			raise ApiError(400, ErrorCode.SOURCE_FLAGGED)
-		if not is_editor and work.status == Status.APPROVED:
-			src.is_pending = True
-			transaction.on_commit(
-				lambda: enqueue_deferred(
-					resolve_expired_source_task,
-					src.pk,
-					delay=settings.OTODB_MODERATION_PERIOD,
-				)
-			)
-		sync_work_source(work, src)
-		return {'work_id': work.pk}
 
-	# New source, no existing work -> return source_id for review
-	return {'source_id': src.pk}
+		if src is None:
+			raise ApiError(400, ErrorCode.BAD_URL)
+
+		src = WorkSource.objects.select_for_update(of=('self',)).get(pk=src.pk)
+
+		# Source already has a work -> redirect
+		if src.media:
+			return {'work_id': src.media.pk}
+
+		# work_id provided -> bind source to existing work
+		if work_id:
+			work = get_object_or_404(
+				MediaWork.objects.filter(moved_to__isnull=True), id=work_id
+			)
+			if work.status == Status.DELISTED:
+				raise ApiError(400, ErrorCode.SOURCE_UNAPPROVED)
+			if work.moderation_events.filter(
+				event_type=ModerationEventType.FLAG, status=FlagStatus.PENDING
+			).exists():
+				raise ApiError(400, ErrorCode.SOURCE_FLAGGED)
+			if not is_editor and work.status == Status.APPROVED:
+				src.is_pending = True
+				transaction.on_commit(
+					lambda: enqueue_deferred(
+						resolve_expired_source_task,
+						src.pk,
+						delay=settings.OTODB_MODERATION_PERIOD,
+					)
+				)
+			sync_work_source(work, src)
+			return {'work_id': work.pk}
+
+		# New source, no existing work -> return source_id for review
+		return {'source_id': src.pk}
+
+	return await sync_to_async(make_source)()
 
 
 def resolve_creator_tags(src: WorkSource, info: dict) -> list:

--- a/backend/otodb/common.py
+++ b/backend/otodb/common.py
@@ -63,19 +63,16 @@ def slugify_tag(s: str):
 	return slugify(canonicalize_tag(s), allow_unicode=True)
 
 
-def _make_playlist_ydl():
-	ydl_playlist = YoutubeDL(
-		{'http_headers': {'Accept-Language': 'ja'}, 'extract_flat': True},
-		auto_init=True,
-	)
-	for e in (
-		YoutubeTabIE,
-		NiconicoPlaylistIE,
-		BilibiliFavoritesListIE,
-		SoundcloudPlaylistIE,
-	):
-		ydl_playlist.add_info_extractor(e)
-	return ydl_playlist
+ydl_playlist = YoutubeDL(
+	{'http_headers': {'Accept-Language': 'ja'}, 'extract_flat': True}, auto_init=True
+)
+for e in (
+	YoutubeTabIE,
+	NiconicoPlaylistIE,
+	BilibiliFavoritesListIE,
+	SoundcloudPlaylistIE,
+):
+	ydl_playlist.add_info_extractor(e)
 
 
 ydl, jar = None, None
@@ -354,9 +351,7 @@ async def playlist_info(link):
 		'description': 'description',
 		'entries': 'entries',
 	}
-	info = await asyncio.to_thread(
-		lambda: _make_playlist_ydl().extract_info(link, download=False)
-	)
+	info = await asyncio.to_thread(ydl_playlist.extract_info, link, download=False)
 	if info.get('_type') != 'playlist':
 		return None
 

--- a/backend/otodb/common.py
+++ b/backend/otodb/common.py
@@ -63,16 +63,20 @@ def slugify_tag(s: str):
 	return slugify(canonicalize_tag(s), allow_unicode=True)
 
 
-ydl_playlist = YoutubeDL(
-	{'http_headers': {'Accept-Language': 'ja'}, 'extract_flat': True}, auto_init=True
-)
-for e in (
-	YoutubeTabIE,
-	NiconicoPlaylistIE,
-	BilibiliFavoritesListIE,
-	SoundcloudPlaylistIE,
-):
-	ydl_playlist.add_info_extractor(e)
+def _make_playlist_ydl():
+	ydl_playlist = YoutubeDL(
+		{'http_headers': {'Accept-Language': 'ja'}, 'extract_flat': True},
+		auto_init=True,
+	)
+	for e in (
+		YoutubeTabIE,
+		NiconicoPlaylistIE,
+		BilibiliFavoritesListIE,
+		SoundcloudPlaylistIE,
+	):
+		ydl_playlist.add_info_extractor(e)
+	return ydl_playlist
+
 
 ydl, jar = None, None
 
@@ -308,7 +312,7 @@ def process_video_info(full_info, link=None):
 		return None
 
 
-async def video_info(link, expected_unavailable=False):
+def _video_info_sync(link, expected_unavailable=False):
 	try:
 		if NiconicoIECustom.suitable(link):
 			full_info = get_niconico_geoblocked(NiconicoIECustom.get_temp_id(link))
@@ -324,7 +328,7 @@ async def video_info(link, expected_unavailable=False):
 				link = f.url
 				assert YoutubeIE.suitable(link)
 
-			full_info = await asyncio.to_thread(ydl.extract_info, link, download=False)
+			full_info = ydl.extract_info(link, download=False)
 			info = process_video_info(full_info)
 			return info, full_info
 	except DownloadError as e:
@@ -340,13 +344,19 @@ async def video_info(link, expected_unavailable=False):
 		return None, None
 
 
+async def video_info(link, expected_unavailable=False):
+	return await asyncio.to_thread(_video_info_sync, link, expected_unavailable)
+
+
 async def playlist_info(link):
 	keys = {
 		'title': 'title',
 		'description': 'description',
 		'entries': 'entries',
 	}
-	info = await asyncio.to_thread(ydl_playlist.extract_info, link, download=False)
+	info = await asyncio.to_thread(
+		lambda: _make_playlist_ydl().extract_info(link, download=False)
+	)
 	if info.get('_type') != 'playlist':
 		return None
 

--- a/backend/otodb/common.py
+++ b/backend/otodb/common.py
@@ -1,3 +1,4 @@
+import asyncio
 import html
 import json
 import logging
@@ -307,7 +308,7 @@ def process_video_info(full_info, link=None):
 		return None
 
 
-def video_info(link, expected_unavailable=False):
+async def video_info(link, expected_unavailable=False):
 	try:
 		if NiconicoIECustom.suitable(link):
 			full_info = get_niconico_geoblocked(NiconicoIECustom.get_temp_id(link))
@@ -323,7 +324,7 @@ def video_info(link, expected_unavailable=False):
 				link = f.url
 				assert YoutubeIE.suitable(link)
 
-			full_info = ydl.extract_info(link, download=False)
+			full_info = await asyncio.to_thread(ydl.extract_info, link, download=False)
 			info = process_video_info(full_info)
 			return info, full_info
 	except DownloadError as e:

--- a/backend/otodb/common.py
+++ b/backend/otodb/common.py
@@ -340,13 +340,13 @@ async def video_info(link, expected_unavailable=False):
 		return None, None
 
 
-def playlist_info(link):
+async def playlist_info(link):
 	keys = {
 		'title': 'title',
 		'description': 'description',
 		'entries': 'entries',
 	}
-	info = ydl_playlist.extract_info(link, download=False)
+	info = await asyncio.to_thread(ydl_playlist.extract_info, link, download=False)
 	if info.get('_type') != 'playlist':
 		return None
 

--- a/backend/otodb/middleware.py
+++ b/backend/otodb/middleware.py
@@ -1,19 +1,12 @@
 from django.core.cache import cache
 from django.http import HttpResponse
-from django.utils.cache import (
-	get_cache_key,
-	get_max_age,
-	learn_cache_key,
-	patch_response_headers,
-)
+from django.utils.cache import get_max_age, patch_response_headers
 
 CACHE_TIMEOUT = 60
 KEY_PREFIX = 'anon_api'
 
 # Paths cached for everyone, including authenticated users, with per-prefix
-# timeouts in seconds. These responses don't vary by user, language, or
-# origin, so they use a deterministic path+query key and skip Django's
-# Vary-aware machinery.
+# timeouts in seconds.
 ALWAYS_CACHE_PREFIXES = {
 	'/api/stats': 60,
 	'/sitemap.xml': 3600,
@@ -51,6 +44,11 @@ def _always_cache_key(request) -> str:
 	return f'{KEY_PREFIX}:always:{request.method}:{request.get_full_path()}'
 
 
+def _anon_cache_key(request) -> str:
+	origin = request.headers.get('Origin', '')
+	return f'{KEY_PREFIX}:anon:{request.method}:{origin}:{request.get_full_path()}'
+
+
 class AnonymousReadOnlyCacheMiddleware:
 	def __init__(self, get_response):
 		self.get_response = get_response
@@ -70,21 +68,14 @@ class AnonymousReadOnlyCacheMiddleware:
 
 	def __call__(self, request):
 		always_timeout: int | None = None
-		anon_eligible = False
+		cache_key = None
 
 		if request.method in ('GET', 'HEAD'):
 			always_timeout = self._always_timeout(request)
 			if always_timeout is not None:
 				cache_key = _always_cache_key(request)
 			elif self._is_anon_eligible(request):
-				anon_eligible = True
-				cache_key = get_cache_key(
-					request, key_prefix=KEY_PREFIX, method=request.method
-				)
-			else:
-				cache_key = None
-		else:
-			cache_key = None
+				cache_key = _anon_cache_key(request)
 
 		if cache_key is not None:
 			cached = cache.get(cache_key)
@@ -98,14 +89,10 @@ class AnonymousReadOnlyCacheMiddleware:
 
 		if always_timeout is not None:
 			patch_response_headers(response, always_timeout)
-			cache.set(_always_cache_key(request), _pack(response), always_timeout)
-		elif anon_eligible:
+			cache.set(cache_key, _pack(response), always_timeout)
+		elif cache_key is not None:
 			timeout = get_max_age(response) or CACHE_TIMEOUT
 			patch_response_headers(response, timeout)
-			cache.set(
-				learn_cache_key(request, response, timeout, KEY_PREFIX),
-				_pack(response),
-				timeout,
-			)
+			cache.set(cache_key, _pack(response), timeout)
 
 		return response

--- a/backend/otodb/models/pool.py
+++ b/backend/otodb/models/pool.py
@@ -23,6 +23,7 @@ class Pool(models.Model):
 		from django.db.models import QuerySet
 
 		poolitem_set: QuerySet['PoolItem']
+		author_id: int
 
 	def __str__(self) -> str:
 		return f'{self.name}'

--- a/backend/otodb/models/work_source.py
+++ b/backend/otodb/models/work_source.py
@@ -154,7 +154,7 @@ class WorkSource(RevisionTrackedModel):
 	@staticmethod
 	def from_url(
 		url, user, is_reupload, info, full_info, metadata=None
-	) -> tuple['WorkSource | None']:
+	) -> 'WorkSource | None':
 		"""
 		Gets or creates a WorkSource from a URL.
 

--- a/backend/otodb/models/work_source.py
+++ b/backend/otodb/models/work_source.py
@@ -7,7 +7,7 @@ import requests
 from django.conf import settings
 from django.db import models
 
-from otodb.common import fetch_thumbnail_mime_type, process_video_info, video_info
+from otodb.common import fetch_thumbnail_mime_type
 from otodb.storage_manager import storage_manager
 
 from .enums import MimeType, Platform, WorkOrigin, WorkStatus
@@ -92,20 +92,10 @@ class WorkSource(RevisionTrackedModel):
 		verbose_name_plural = 'Media Sources'
 		ordering = ['work_status', 'work_origin', 'published_date']
 
-	async def refresh(self, use_cache=False):
+	def refresh(self, info, full_info):
 		"""
 		Refresh work source information.
-
-		Args:
-		    use_cache: If `True`, use previously cached payload instead of requesting new data.
 		"""
-		full_info = None
-
-		if use_cache and getattr(self, 'info_payload', None):
-			info = process_video_info(self.info_payload.payload, self.url)
-		else:
-			info, full_info = await video_info(self.url)
-
 		if info:
 			self.title = info['title']
 			self.description = info['description']
@@ -117,7 +107,7 @@ class WorkSource(RevisionTrackedModel):
 			self.work_duration = info.get('work_duration', self.work_duration)
 
 			# Re-upload thumbnail to CDN for non-cached refreshes
-			if not use_cache and self.thumbnail_url and self.thumbnail_mime:
+			if self.thumbnail_url and self.thumbnail_mime:
 				self.save_thumbnail()
 
 			if full_info is not None:
@@ -164,7 +154,7 @@ class WorkSource(RevisionTrackedModel):
 	@staticmethod
 	def from_url(
 		url, user, is_reupload, info, full_info, metadata=None
-	) -> tuple['WorkSource | None', 'dict | None']:
+	) -> tuple['WorkSource | None']:
 		"""
 		Gets or creates a WorkSource from a URL.
 
@@ -177,7 +167,7 @@ class WorkSource(RevisionTrackedModel):
 		    metadata: Optional metadata dict for unavailable sources (editors only)
 
 		Returns:
-		    WorkSourc or None if failed
+		    WorkSource or None if failed
 		"""
 		from otodb.common import (
 			fetch_thumbnail_mime_type,

--- a/backend/otodb/models/work_source.py
+++ b/backend/otodb/models/work_source.py
@@ -92,7 +92,7 @@ class WorkSource(RevisionTrackedModel):
 		verbose_name_plural = 'Media Sources'
 		ordering = ['work_status', 'work_origin', 'published_date']
 
-	def refresh(self, use_cache=False):
+	async def refresh(self, use_cache=False):
 		"""
 		Refresh work source information.
 
@@ -104,7 +104,7 @@ class WorkSource(RevisionTrackedModel):
 		if use_cache and getattr(self, 'info_payload', None):
 			info = process_video_info(self.info_payload.payload, self.url)
 		else:
-			info, full_info = video_info(self.url)
+			info, full_info = await video_info(self.url)
 
 		if info:
 			self.title = info['title']
@@ -163,31 +163,27 @@ class WorkSource(RevisionTrackedModel):
 	# Gets the source registered at the url if it exists, otherwise register as pending
 	@staticmethod
 	def from_url(
-		url, user, is_reupload, metadata=None, info=None, full_info=None
+		url, user, is_reupload, info, full_info, metadata=None
 	) -> tuple['WorkSource | None', 'dict | None']:
 		"""
 		Gets or creates a WorkSource from a URL.
 
 		Args:
 		    url: The URL to fetch
+		    info: Info dict
+		    full_info: Full info dict
 		    user: The user adding the source
 		    is_reupload: Whether this is a reupload (not by original author)
 		    metadata: Optional metadata dict for unavailable sources (editors only)
-		    info: Optional pre-fetched info dict (for optimization)
-		    full_info: Optional pre-fetched full info dict (for optimization)
 
 		Returns:
-		    Tuple of (WorkSource, info_dict) or (None, None) if failed
+		    WorkSourc or None if failed
 		"""
 		from otodb.common import (
 			fetch_thumbnail_mime_type,
 			make_video_url,
 			platform_extractors,
 		)
-
-		# Try to fetch info if not provided
-		if info is None:
-			info, full_info = video_info(url, expected_unavailable=metadata is not None)
 
 		# Handle unavailable sources
 		if info is None and metadata is not None:
@@ -212,10 +208,10 @@ class WorkSource(RevisionTrackedModel):
 						break
 				else:
 					logger.error(f'No suitable platform extractor found for URL: {url}')
-					return None, None
+					return None
 			except Exception:
 				logger.error(f'Failed to parse URL for platform: {url}')
-				return None, None
+				return None
 
 			published_date = metadata.get('published_date') if metadata else None
 			thumbnail_url = metadata.get('thumbnail_url') if metadata else None
@@ -246,10 +242,10 @@ class WorkSource(RevisionTrackedModel):
 			}
 		elif info is None:
 			logger.error(f'Failed to get video info for URL: {url}')
-			return None, None
+			return None
 
 		if info['site'] is None:
-			return None, None
+			return None
 
 		# Check if source already exists
 		try:
@@ -285,7 +281,7 @@ class WorkSource(RevisionTrackedModel):
 			if src.thumbnail_url and src.thumbnail_mime:
 				src.save_thumbnail()
 
-		return src, info
+		return src
 
 	@property
 	def thumbnail_path(self) -> str:

--- a/backend/otodb/ytdlp_custom.py
+++ b/backend/otodb/ytdlp_custom.py
@@ -46,17 +46,23 @@ class TwitterIECustom(TwitterIE):
 				status['note_tweet'] = note
 		return status
 
-	# Stash the raw status so _real_extract can rebuild description from it
+	# Stash raw status so _real_extract can rebuild description from it.
+	# Keyed by tweet id
+	_statuses = {}
+
 	def _extract_status(self, twid):
 		status = super()._extract_status(twid)
-		self._otodb_status = status if isinstance(status, dict) else None
+		if isinstance(status, dict):
+			self._statuses[twid] = status
 		return status
 
 	# Rebuild description with newlines preserved, links expanded, media t.co stripped
 	def _real_extract(self, url):
-		self._otodb_status = None
-		info = super()._real_extract(url)
-		status = getattr(self, '_otodb_status', None)
+		twid = self._match_id(url)
+		try:
+			info = super()._real_extract(url)
+		finally:
+			status = self._statuses.pop(twid, None)
 		if isinstance(info, dict) and 'description' in info and status:
 			note = status.get('note_tweet')
 			if note:

--- a/backend/project/asgi.py
+++ b/backend/project/asgi.py
@@ -14,3 +14,11 @@ from django.core.asgi import get_asgi_application
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
 
 application = get_asgi_application()
+
+if trusted_hosts := os.environ.get('OTODB_TRUSTED_PROXY_HOSTS'):
+	from granian.utils.proxies import wrap_asgi_with_proxy_headers
+
+	application = wrap_asgi_with_proxy_headers(
+		application,
+		trusted_hosts=[h.strip() for h in trusted_hosts.split(',')],
+	)

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -124,6 +124,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'project.wsgi.application'
+ASGI_APPLICATION = 'project.asgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -57,4 +57,5 @@ dev = [
     "pre-commit>=4.5.1",
     "pytest>=9.0.3",
     "pytest-django>=4.12.0",
+    "pytest-asyncio>=1.4.0",
 ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.test import RequestFactory
-from ninja.testing import TestClient
+from ninja.testing import TestAsyncClient, TestClient
 
 from otodb.account.models import Account
 from otodb.api.auth import auth_router
@@ -19,6 +19,21 @@ def clear_cache():
 	cache.clear()
 	yield
 	cache.clear()
+
+
+class AuthenticatedAsyncTestClient(TestAsyncClient):
+	"""TestClient that automatically uses a real user for all requests."""
+
+	def __init__(self, router, user):
+		super().__init__(router)
+		self.test_user = user
+
+	def _build_request(self, method, path, data, request_params):
+		"""Override to set real user on request object."""
+		# If no user was explicitly provided, use our default test user
+		if 'user' not in request_params:
+			request_params['user'] = self.test_user
+		return super()._build_request(method, path, data, request_params)
 
 
 class AuthenticatedTestClient(TestClient):
@@ -110,6 +125,12 @@ def tag_client(member):
 def source_client(member):
 	"""Create a test client for the source router."""
 	return AuthenticatedTestClient(source_router, member)
+
+
+@pytest.fixture
+def async_source_client(member):
+	"""Create a test client for the source router."""
+	return AuthenticatedAsyncTestClient(source_router, member)
 
 
 @pytest.fixture

--- a/backend/tests/test_work.py
+++ b/backend/tests/test_work.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import random
 import string
@@ -55,13 +56,13 @@ def base_video_info():
 def video_info_mock(base_video_info):
 	"""Create a mock for video_info with fuzzed data."""
 	fuzzed = fuzz_video_infos(base_video_info)
-	with patch('otodb.models.work_source.video_info') as mock:
+	with patch('otodb.api.source.video_info') as mock:
 		mock.return_value = fuzzed
 		yield mock, fuzzed
 
 
 @pytest.fixture
-def add_source(source_client):
+def add_source(async_source_client):
 	"""Helper to create a source via the source API."""
 
 	def _add(
@@ -76,9 +77,11 @@ def add_source(source_client):
 		if work_id is not None:
 			query_params['work_id'] = work_id
 
-		return source_client.post(
-			'/source?' + urlencode(query_params),
-			user=user,
+		return asyncio.run(
+			async_source_client.post(
+				'/source?' + urlencode(query_params),
+				user=user,
+			)
 		)
 
 	return _add

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -745,6 +745,7 @@ dev = [
     { name = "django-silk" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-django" },
 ]
 
@@ -782,6 +783,7 @@ dev = [
     { name = "django-silk", specifier = ">=5.5.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-django", specifier = ">=4.12.0" },
 ]
 
@@ -985,6 +987,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Alternative to #835. closes #835 

- Organization and user flow is definitely cleaner this way. The alternative is to set up polling on the task. Can just add threads to scale with this setup.
- Running sync handlers under ASGI has a penalty, but the cost has to be profiled.
- This may still not be good enough and #835 might still be required (needs profiling vs master). But I feel that this is a quick win over the way it is now.