### PR TITLE
Add `list` metatag

### DIFF
--- a/backend/otodb/api/work.py
+++ b/backend/otodb/api/work.py
@@ -33,6 +33,7 @@ from otodb.common import (
 from otodb.models import (
 	MediaWork,
 	ModerationEvent,
+	PoolItem,
 	RevisionChange,
 	RevisionChangeEntity,
 	TagWork,
@@ -416,6 +417,14 @@ work_metatag_grammars = {
 		),
 	),
 	'id': MetatagSpec(int, make_range_metatag('id')),
+	'list': MetatagSpec(
+		str,
+		lambda v: (
+			Exists(PoolItem.objects.filter(work_id=OuterRef('id'), pool_id=v))
+			if v.isdigit()
+			else Q(pk__in=[])
+		),
+	),
 	'width': MetatagSpec(
 		int,
 		make_range_metatag('work_width', model=WorkSource, fk_field='media_id'),


### PR DESCRIPTION
Feature request from Discord (also something I realized a few days ago we should have): https://discord.com/channels/1393616615395954750/1393616616247525402/1525438487351005246

Checks works that exist in the given list ID. Syntax is `list:{id}`. This is intentionally not a range metatag since it doesn't make sense to do that in this context.