### PR TITLE
Add storybook script for agent

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -56,6 +56,11 @@ When making any changes to frontend code, you MUST run the following commands in
 
 All three commands must succeed without errors before committing. Do not skip or bypass these checks.
 
+## Storybook
+
+- When a coding agent starts Storybook, always use `bun run storybook:agent`, not `bun run storybook`. It runs with `--quiet --ci --disable-telemetry --no-version-updates` to minimize console output and token usage, and it does not pass `--no-open`, so it may open a browser automatically.
+- `bun run storybook` (without those flags) is reserved for a human developer running Storybook interactively.
+
 ## Coding
 
 - When importing components or libraries in `lib`, use `$lib` for import path.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
 		"test:watch": "bun test --watch",
 		"lint": "eslint .",
 		"storybook": "storybook dev -p 6006 --no-open",
+		"storybook:agent": "storybook dev -p 6006 --quiet --ci --disable-telemetry --no-version-updates",
 		"build-storybook": "storybook build",
 		"sync-schema": "openapi-typescript --enum",
 		"sync-schema:watch": "chokidar './openapi.json' --follow-symlinks --initial -c 'bun run sync-schema'"


### PR DESCRIPTION
## Summary
- Add a `storybook:agent` script to `frontend/package.json` running `storybook dev -p 6006 --quiet --ci --disable-telemetry --no-version-updates`, intended for use by coding agents to reduce noisy output and avoid interactive telemetry/version-update prompts.

## Test plan
- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run check`