### PR TITLE
Lower the `/api/work/random` and `/api/work/recent` result cap from 20 to 18

### DIFF
--- a/backend/otodb/api/work.py
+++ b/backend/otodb/api/work.py
@@ -754,13 +754,13 @@ def random(request: AuthedHttpRequest, n: int = 1):
 	return (
 		MediaWork.active_objects.visible()
 		.filter(rating=Rating.GENERAL)
-		.order_by('?')[: min(n, 20)]
+		.order_by('?')[: min(n, 18)]
 	)
 
 
 @work_router.get('recent', response=list[ThinWorkSchema], exclude_none=True)
 def recent(request: AuthedHttpRequest, n: int = 1):
-	return MediaWork.active_objects.visible().order_by('-id')[: min(n, 20)]
+	return MediaWork.active_objects.visible().order_by('-id')[: min(n, 18)]
 
 
 @work_router.get(


### PR DESCRIPTION
## Summary
- Lower the hardcoded result cap on `/api/work/random` and `/api/work/recent` from `min(n, 20)` to `min(n, 18)`
- Matches the new default page size of 18 on the `/work` search page (#950)

## Test plan
- [x] `uvx ruff format` / `uvx ruff check`
- [x] `uv run manage.py openapi_schema` (no schema diff — `n` has no declared max in the OpenAPI schema)
- [x] `uv run pytest tests/test_work.py` (9 passed)