### PR TITLE
Unify sampleable tag logic on backend

### DIFF
--- a/backend/otodb/api/tag.py
+++ b/backend/otodb/api/tag.py
@@ -593,6 +593,7 @@ def update(
 	tag = get_object_or_404(
 		TagWork.objects.select_for_update(of=('self',)), slug=tag_slug
 	)
+	original_category = tag.category
 	if (
 		tag.category == WorkTagCategory.SONG
 		and payload.category != WorkTagCategory.SONG
@@ -613,10 +614,13 @@ def update(
 		except MediaSong.DoesNotExist:
 			tag.category = WorkTagCategory.SONG
 			song = MediaSong.objects.create(work_tag=tag, **song_payload.dict())
-	# If category changed from source to creator or media, mark all instances with used_as_source
-	if tag.category == WorkTagCategory.SOURCE and payload.category in (
-		WorkTagCategory.CREATOR,
-		WorkTagCategory.MEDIA,
+	# If category changed from source to a sampleable category, preserve the
+	# existing entries as a source by marking all instances used_as_source.
+	# Compare against the original category since the song branch above may
+	# have already reassigned tag.category in memory.
+	if (
+		original_category == WorkTagCategory.SOURCE
+		and payload.category in WorkTagCategory.sampleable()
 	):
 		TagWorkInstance.objects.filter(work_tag=tag).update(used_as_source=True)
 

--- a/backend/otodb/api/work.py
+++ b/backend/otodb/api/work.py
@@ -113,11 +113,7 @@ def _resolve_and_apply_tags(work, payload: list[TagWorkInstanceInSchema]):
 
 	for tag, p in zip(tags, payload):
 		changes = {}
-		if p.sample is not None and tag.category in [
-			WorkTagCategory.CREATOR,
-			WorkTagCategory.MEDIA,
-			WorkTagCategory.SONG,
-		]:
+		if p.sample is not None and tag.category in WorkTagCategory.sampleable():
 			changes['used_as_source'] = p.sample
 		if p.roles and tag.category == WorkTagCategory.CREATOR:
 			changes['creator_roles'] = reduce(int.__or__, p.roles)

--- a/backend/otodb/models/enums.py
+++ b/backend/otodb/models/enums.py
@@ -25,6 +25,11 @@ class WorkTagCategory(OtodbIntegerEnum):
 	MEDIA = 6, 'Media'
 	GENERAL = 7, 'General'
 
+	@classmethod
+	def sampleable(cls):
+		"""Categories whose tags can be marked as a sample (`used_as_source`)."""
+		return [cls.CREATOR, cls.MEDIA, cls.SONG]
+
 
 class SongTagCategory(OtodbIntegerEnum):
 	GENERAL = 0, 'General'


### PR DESCRIPTION
Follow-up to https://github.com/otoDB/otoDB/pull/419, handles the issue described here: https://otodb.net/thread/145