### PR TITLE
Give the comments table a fixed layout so columns stop shifting between pages

### DIFF
--- a/frontend/src/routes/comments/+page.svelte
+++ b/frontend/src/routes/comments/+page.svelte
@@ -10,23 +10,29 @@
 </script>
 
 <Section title={m.same_broad_haddock_pinch()}>
-	<table>
+	<table class="w-full table-fixed">
+		<colgroup>
+			<col class="w-2/12" />
+			<col class="w-2/12" />
+			<col />
+			<col class="w-2/12" />
+		</colgroup>
 		<tbody>
 			{#each data.comments?.items as c, i (i)}
 				{@const link = buildEntityRoutes(c.entity_type as EntityModelType, c.entity_id)}
 				<tr>
-					<td>
+					<td class="wrap-anywhere">
 						<a href={link}>
 							{link}
 						</a>
 					</td>
-					<td>
+					<td class="wrap-anywhere">
 						<a href="/profile/{c.user.username}">{c.user.username}</a>
 					</td>
-					<td>
+					<td class="wrap-anywhere">
 						{c.comment}
 					</td>
-					<td>
+					<td class="wrap-anywhere">
 						<Time format="relative" date={c.submit_date} />
 					</td>
 				</tr>

--- a/frontend/src/routes/comments/page.stories.ts
+++ b/frontend/src/routes/comments/page.stories.ts
@@ -38,7 +38,9 @@ const commenter = (id: string, username: string, level: Levels) => ({
 });
 
 // One template per entity type `buildEntityRoutes` knows about, so every link
-// shape the table can produce is exercised.
+// shape the table can produce is exercised. A couple of them deliberately carry
+// unbreakable content — a bare long URL, a long tag slug — because those are what
+// used to blow the column widths out and push the table past the section.
 const templates = [
 	{
 		user: commenter('1', 'member_user', Levels.Member),
@@ -50,7 +52,7 @@ const templates = [
 		user: commenter('2', 'editor_user', Levels.Editor),
 		comment: 'Aliased this tag to the canonical spelling.',
 		entity_type: 'tagwork',
-		entity_id: 'sample-tag'
+		entity_id: 'a-deliberately-long-sample-tag-slug'
 	},
 	{
 		user: commenter('3', 'mod_user', Levels.Mod),
@@ -61,7 +63,7 @@ const templates = [
 	{
 		user: commenter('4', 'restricted_user', Levels.Restricted),
 		comment:
-			'A considerably longer comment that wraps onto several lines, so the table layout can be checked against realistic prose rather than a single short sentence. It also mentions https://example.com to show how raw URLs are rendered here.',
+			'A considerably longer comment that wraps onto several lines, so the table layout can be checked against realistic prose rather than a single short sentence. It also pastes a bare source link, https://example.com/watch?v=aVeryLongVideoIdentifier&list=AnEquallyLongPlaylistIdentifier&index=12, which has no break opportunity in it at all.',
 		entity_type: 'wikipage',
 		entity_id: 'style-guide'
 	},


### PR DESCRIPTION
## Problem

The table on `/comments` used the default auto table layout with no width constraints, so every column was sized from whatever content happened to land on that page.

Measured against production at a 1280px viewport:

| | `main` width | column widths |
| --- | --- | --- |
| `/comments?page=1` | 976px | 104 / 86 / 654 / 89 |
| `/comments?page=2` | 1203px | 151 / 113 / 809 / 86 |

Two things go wrong:

1. **Columns move between pages.** Nothing is pinned, so paging back and forth reflows the whole table. Because `main` lives inside `<div class="grow">` in a flex row, an oversized table also drags the entire content column — and with it the page header and pager — wider.
2. **Long content overflows horizontally.** Comments frequently contain a bare pasted URL, which offers no break opportunity. At a 420px viewport the page-2 table renders 1160px wide inside a 388px container, spilling straight out past the section border.

## Fix

Switch the table to `w-full table-fixed` with a `<colgroup>`, the idiom already used by `ThreadTable.svelte` and the user list on `/profile`. The entity link, author and timestamp columns each take a twelfth of the width; the comment text takes the remainder. `wrap-anywhere` on the cells lets long URLs and long tag slugs break instead of pushing the column out.

With the same change applied to production page 2, `main` collapses from 1203px back to 976px and the columns settle at 156 / 156 / 467 / 156 — identical on every page. At 420px the table renders 346px inside its 388px container, so nothing overflows any more.

## Story

`page.stories.ts` now carries a bare long URL and a long tag slug in its fixtures, so the content shape that used to break the layout is visible in Storybook rather than only in production.