### PR TITLE
Add a contribution heatmap to `/profile/[username]`

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -453,5 +453,8 @@
 	"bold_keen_otter_vault": "Rollback to before this revision",
 	"tame_swift_heron_plead": "Rollback ALL revisions made by {username} to before {label}?",
 	"hazy_calm_otter_dream": "Plain Dark",
-	"misty_plain_finch_glow": "Plain Light"
+	"misty_plain_finch_glow": "Plain Light",
+	"brave_deep_falcon_soar": "Recent activity",
+	"plain_swift_otter_gather": "{count} contributions in the last year",
+	"warm_still_marmot_reflect": "{count} contributions on {date}"
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -318,5 +318,8 @@
 	"bold_keen_otter_vault": "この変更より前にロールバック",
 	"tame_swift_heron_plead": "{username} のすべての変更を {label} より前にロールバックしますか？",
 	"hazy_calm_otter_dream": "無地（ダーク）",
-	"misty_plain_finch_glow": "無地（ライト）"
+	"misty_plain_finch_glow": "無地（ライト）",
+	"brave_deep_falcon_soar": "最近の活動",
+	"plain_swift_otter_gather": "過去1年間で{count}件の貢献",
+	"warm_still_marmot_reflect": "{date}に{count}件の貢献"
 }

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -318,5 +318,8 @@
 	"bold_keen_otter_vault": "이 변경 이전으로 롤백",
 	"tame_swift_heron_plead": "{username}님의 모든 변경을 {label} 이전으로 롤백하시겠습니까?",
 	"hazy_calm_otter_dream": "무지 다크",
-	"misty_plain_finch_glow": "무지 라이트"
+	"misty_plain_finch_glow": "무지 라이트",
+	"brave_deep_falcon_soar": "최근 활동",
+	"plain_swift_otter_gather": "지난 1년간 {count}건의 기여",
+	"warm_still_marmot_reflect": "{date}에 {count}건의 기여"
 }

--- a/frontend/messages/zh-cn.json
+++ b/frontend/messages/zh-cn.json
@@ -319,5 +319,8 @@
 	"bold_keen_otter_vault": "回滚到此更改之前",
 	"tame_swift_heron_plead": "将 {username} 的所有更改回滚到 {label} 之前？",
 	"hazy_calm_otter_dream": "素色深色",
-	"misty_plain_finch_glow": "素色浅色"
+	"misty_plain_finch_glow": "素色浅色",
+	"brave_deep_falcon_soar": "最近活动",
+	"plain_swift_otter_gather": "过去一年共 {count} 次贡献",
+	"warm_still_marmot_reflect": "{date} 有 {count} 次贡献"
 }

--- a/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.stories.ts
+++ b/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.stories.ts
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import type { ComponentProps } from 'svelte';
+import ActivityHeatmap from './ActivityHeatmap.svelte';
+import type { ProfileActivity } from './types';
+
+/**
+ * The window is hard-coded rather than derived from the current date so the stories render
+ * identically on every run. `2025-01-01` … `2025-12-31` is exactly the 365 days the API
+ * returns (`start` = `end` − 364).
+ */
+const START = '2025-01-01';
+const END = '2025-12-31';
+const WINDOW_DAYS = 365;
+const MS_PER_DAY = 86_400_000;
+
+const startTime = Date.parse(`${START}T00:00:00Z`);
+const dayAt = (index: number) =>
+	new Date(startTime + index * MS_PER_DAY).toISOString().slice(0, 10);
+
+/**
+ * A deterministic 0..1 value per day index, standing in for a seeded RNG — `Math.random()`
+ * would make the stories non-reproducible.
+ */
+const noise = (index: number) => {
+	let x = Math.imul(index + 1, 2654435761);
+	x ^= x >>> 15;
+	x = Math.imul(x, 2246822519);
+	x ^= x >>> 13;
+	return (x >>> 0) / 4294967296;
+};
+
+const buildActivity = (count: (index: number, value: number) => number): ProfileActivity => {
+	const days = [];
+	let total = 0;
+
+	for (let index = 0; index < WINDOW_DAYS; index++) {
+		const value = count(index, noise(index));
+		if (value <= 0) continue;
+		days.push({ date: dayAt(index), count: value });
+		total += value;
+	}
+
+	return { start: START, end: END, total, days };
+};
+
+/** An active user: most days have contributions, spread over the whole range of levels. */
+const dense = buildActivity((_, value) => (value < 0.12 ? 0 : 1 + Math.floor(value * 11)));
+
+/** An occasional contributor: a handful of low-count days scattered across the year. */
+const sparse = buildActivity((_, value) => (value < 0.9 ? 0 : 1 + Math.floor(value * 3)));
+
+/**
+ * One burst of activity far above everything else — e.g. a bulk import. It pins the level
+ * scale, so every ordinary day collapses to level 1.
+ */
+const outlier = buildActivity((index, value) => {
+	if (index === 214) return 480;
+	return value < 0.4 ? 0 : 1 + Math.floor(value * 5);
+});
+
+const meta = {
+	component: ActivityHeatmap,
+	args: { activity: dense }
+} satisfies Meta<ComponentProps<typeof ActivityHeatmap>>;
+
+export default meta;
+type Story = StoryObj<ComponentProps<typeof ActivityHeatmap>>;
+
+/** A year with contributions on most days. */
+export const Dense: Story = {
+	args: { activity: dense }
+};
+
+/** A year with only a few scattered contributions. */
+export const Sparse: Story = {
+	args: { activity: sparse }
+};
+
+/** A year containing a single very high-count day. */
+export const WithOutlierDay: Story = {
+	args: { activity: outlier }
+};

--- a/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.stories.ts
+++ b/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.stories.ts
@@ -4,12 +4,12 @@ import ActivityHeatmap from './ActivityHeatmap.svelte';
 import type { ProfileActivity } from './types';
 
 /**
- * The window is hard-coded rather than derived from the current date so the stories render
- * identically on every run. `2025-01-01` … `2025-12-31` is exactly the 365 days the API
- * returns (`start` = `end` − 364).
+ * The API returns a window rolling back from today (`start` = `end` − 364), so it starts and
+ * ends mid-month rather than on a calendar year. A fixed pair of dates stands in for it here
+ * so the stories render identically on every run.
  */
-const START = '2025-01-01';
-const END = '2025-12-31';
+const START = '2025-08-08';
+const END = '2026-08-07';
 const WINDOW_DAYS = 365;
 const MS_PER_DAY = 86_400_000;
 

--- a/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.stories.ts
+++ b/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.stories.ts
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/sveltekit';
 import type { ComponentProps } from 'svelte';
 import ActivityHeatmap from './ActivityHeatmap.svelte';
-import type { ProfileActivity } from './types';
+
+type Props = ComponentProps<typeof ActivityHeatmap>;
 
 /**
  * The API returns a window rolling back from today (`start` = `end` − 364), so it starts and
@@ -29,7 +30,7 @@ const noise = (index: number) => {
 	return (x >>> 0) / 4294967296;
 };
 
-const buildActivity = (count: (value: number) => number): ProfileActivity => {
+const buildActivity = (count: (value: number) => number): Props['activity'] => {
 	const days = [];
 	let total = 0;
 
@@ -52,10 +53,10 @@ const sparse = buildActivity((value) => (value < 0.9 ? 0 : 1 + Math.floor(value 
 const meta = {
 	component: ActivityHeatmap,
 	args: { activity: dense }
-} satisfies Meta<ComponentProps<typeof ActivityHeatmap>>;
+} satisfies Meta<Props>;
 
 export default meta;
-type Story = StoryObj<ComponentProps<typeof ActivityHeatmap>>;
+type Story = StoryObj<Props>;
 
 /** A year with contributions on most days. */
 export const Dense: Story = {

--- a/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.stories.ts
+++ b/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.stories.ts
@@ -29,12 +29,12 @@ const noise = (index: number) => {
 	return (x >>> 0) / 4294967296;
 };
 
-const buildActivity = (count: (index: number, value: number) => number): ProfileActivity => {
+const buildActivity = (count: (value: number) => number): ProfileActivity => {
 	const days = [];
 	let total = 0;
 
 	for (let index = 0; index < WINDOW_DAYS; index++) {
-		const value = count(index, noise(index));
+		const value = count(noise(index));
 		if (value <= 0) continue;
 		days.push({ date: dayAt(index), count: value });
 		total += value;
@@ -44,19 +44,10 @@ const buildActivity = (count: (index: number, value: number) => number): Profile
 };
 
 /** An active user: most days have contributions, spread over the whole range of levels. */
-const dense = buildActivity((_, value) => (value < 0.12 ? 0 : 1 + Math.floor(value * 11)));
+const dense = buildActivity((value) => (value < 0.12 ? 0 : 1 + Math.floor(value * 11)));
 
 /** An occasional contributor: a handful of low-count days scattered across the year. */
-const sparse = buildActivity((_, value) => (value < 0.9 ? 0 : 1 + Math.floor(value * 3)));
-
-/**
- * One burst of activity far above everything else — e.g. a bulk import. It pins the level
- * scale, so every ordinary day collapses to level 1.
- */
-const outlier = buildActivity((index, value) => {
-	if (index === 214) return 480;
-	return value < 0.4 ? 0 : 1 + Math.floor(value * 5);
-});
+const sparse = buildActivity((value) => (value < 0.9 ? 0 : 1 + Math.floor(value * 3)));
 
 const meta = {
 	component: ActivityHeatmap,
@@ -74,9 +65,4 @@ export const Dense: Story = {
 /** A year with only a few scattered contributions. */
 export const Sparse: Story = {
 	args: { activity: sparse }
-};
-
-/** A year containing a single very high-count day. */
-export const WithOutlierDay: Story = {
-	args: { activity: outlier }
 };

--- a/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.svelte
+++ b/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import { m } from '$lib/paraglide/messages';
+	import { getLocale } from '$lib/paraglide/runtime';
+	import type { ProfileActivity } from './types';
+
+	interface Props {
+		activity: ProfileActivity;
+	}
+
+	const { activity }: Props = $props();
+
+	const MS_PER_DAY = 86_400_000;
+	const DAYS_PER_WEEK = 7;
+
+	/**
+	 * A fixed Sunday, used only to render the weekday labels. Hard-coded rather than derived
+	 * from the current date so the component stays deterministic.
+	 */
+	const REFERENCE_SUNDAY = Date.UTC(2024, 0, 7);
+
+	/** Every date the component handles is a UTC midnight timestamp of an ISO `YYYY-MM-DD`. */
+	const parseDay = (date: string) => Date.parse(`${date}T00:00:00Z`);
+	const formatDay = (time: number) => new Date(time).toISOString().slice(0, 10);
+
+	const startTime = $derived(parseDay(activity.start));
+	const endTime = $derived(parseDay(activity.end));
+
+	/** Pad back to the Sunday on or before `start` so every column is a full week. */
+	const gridStartTime = $derived(startTime - new Date(startTime).getUTCDay() * MS_PER_DAY);
+	const weeks = $derived(
+		Math.max(1, Math.ceil(((endTime - gridStartTime) / MS_PER_DAY + 1) / DAYS_PER_WEEK))
+	);
+
+	const counts = $derived(new Map(activity.days.map(({ date, count }) => [date, count])));
+	const maxCount = $derived(activity.days.reduce((max, { count }) => Math.max(max, count), 0));
+
+	const level = (count: number) => {
+		if (count === 0 || maxCount === 0) return 0;
+		return Math.min(4, Math.max(1, Math.ceil((count / maxCount) * 4)));
+	};
+
+	const dayFormat = $derived(
+		new Intl.DateTimeFormat(getLocale(), { dateStyle: 'long', timeZone: 'UTC' })
+	);
+	const monthFormat = $derived(
+		new Intl.DateTimeFormat(getLocale(), { month: 'short', timeZone: 'UTC' })
+	);
+	const weekdayFormat = $derived(
+		new Intl.DateTimeFormat(getLocale(), { weekday: 'short', timeZone: 'UTC' })
+	);
+
+	/** GitHub-style: only every other weekday is labelled, to keep the axis readable. */
+	const weekdayLabels = $derived(
+		Array.from({ length: DAYS_PER_WEEK }, (_, row) =>
+			row % 2 === 1 ? weekdayFormat.format(REFERENCE_SUNDAY + row * MS_PER_DAY) : ''
+		)
+	);
+
+	type Cell = { date: string; count: number; label: string } | null;
+
+	const columns: { month: string; cells: Cell[] }[] = $derived.by(() => {
+		const result: { month: string; cells: Cell[] }[] = [];
+		let labelledMonth = -1;
+
+		for (let week = 0; week < weeks; week++) {
+			const cells = Array.from({ length: DAYS_PER_WEEK }, (_, row): Cell => {
+				const time = gridStartTime + (week * DAYS_PER_WEEK + row) * MS_PER_DAY;
+				// Days before `start` (the leading pad) and after `end` are rendered as gaps.
+				if (time < startTime || time > endTime) return null;
+
+				const date = formatDay(time);
+				const count = counts.get(date) ?? 0;
+				return {
+					date,
+					count,
+					label: m.warm_still_marmot_reflect({ count, date: dayFormat.format(time) })
+				};
+			});
+
+			// A column carries a month label the first time that month appears along the top.
+			const first = cells.find((cell) => cell !== null);
+			const time = first ? parseDay(first.date) : 0;
+			const monthIndex = first ? new Date(time).getUTCMonth() : labelledMonth;
+			const month = monthIndex === labelledMonth ? '' : monthFormat.format(time);
+			labelledMonth = monthIndex;
+
+			result.push({ month, cells });
+		}
+
+		return result;
+	});
+</script>
+
+<p class="mb-2">{m.plain_swift_otter_gather({ count: activity.total })}</p>
+
+<div class="flex gap-1 overflow-x-auto pb-1">
+	<div class="text-otodb-content-fainter grid grid-rows-[1rem_repeat(7,0.75rem)] gap-[3px] text-xs">
+		<span></span>
+		{#each weekdayLabels as label, row (row)}
+			<span class="flex items-center pr-1 leading-none">{label}</span>
+		{/each}
+	</div>
+
+	<div
+		class="grid [grid-auto-columns:0.75rem] grid-flow-col grid-rows-[1rem_repeat(7,0.75rem)] gap-[3px]"
+	>
+		{#each columns as column, week (week)}
+			<span class="text-otodb-content-fainter relative text-xs">
+				{#if column.month}
+					<span class="absolute top-0 left-0 whitespace-nowrap">{column.month}</span>
+				{/if}
+			</span>
+			{#each column.cells as cell, row (row)}
+				{#if cell}
+					<span class="cell" data-level={level(cell.count)} title={cell.label}></span>
+				{:else}
+					<span></span>
+				{/if}
+			{/each}
+		{/each}
+	</div>
+</div>
+
+<style>
+	.cell {
+		/* A hairline keeps empty days visible against the surrounding `bg-faint` panel. */
+		outline: 1px solid color-mix(in oklab, var(--otodb-color-content-fainter) 20%, transparent);
+		outline-offset: -1px;
+
+		&[data-level='0'] {
+			background-color: var(--otodb-color-bg-faint);
+		}
+		&[data-level='1'] {
+			background-color: color-mix(in oklab, green 25%, var(--otodb-color-bg-faint));
+		}
+		&[data-level='2'] {
+			background-color: color-mix(in oklab, green 45%, var(--otodb-color-bg-faint));
+		}
+		&[data-level='3'] {
+			background-color: color-mix(in oklab, green 70%, var(--otodb-color-bg-faint));
+		}
+		&[data-level='4'] {
+			background-color: color-mix(in oklab, green 95%, var(--otodb-color-bg-faint));
+		}
+	}
+</style>

--- a/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.svelte
+++ b/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.svelte
@@ -12,12 +12,6 @@
 	const MS_PER_DAY = 86_400_000;
 	const DAYS_PER_WEEK = 7;
 
-	/**
-	 * A fixed Sunday, used only to render the weekday labels. Hard-coded rather than derived
-	 * from the current date so the component stays deterministic.
-	 */
-	const REFERENCE_SUNDAY = Date.UTC(2024, 0, 7);
-
 	/** Every date the component handles is a UTC midnight timestamp of an ISO `YYYY-MM-DD`. */
 	const parseDay = (date: string) => Date.parse(`${date}T00:00:00Z`);
 
@@ -41,16 +35,6 @@
 	);
 	const monthFormat = $derived(
 		new Intl.DateTimeFormat(getLocale(), { month: 'short', timeZone: 'UTC' })
-	);
-	const weekdayFormat = $derived(
-		new Intl.DateTimeFormat(getLocale(), { weekday: 'short', timeZone: 'UTC' })
-	);
-
-	/** GitHub-style: only every other weekday is labelled, to keep the axis readable. */
-	const weekdayLabels = $derived(
-		Array.from({ length: DAYS_PER_WEEK }, (_, row) =>
-			row % 2 === 1 ? weekdayFormat.format(REFERENCE_SUNDAY + row * MS_PER_DAY) : ''
-		)
 	);
 
 	type Cell = { count: number; label: string } | null;
@@ -88,16 +72,9 @@
 
 <p class="mb-2">{m.plain_swift_otter_gather({ count: activity.total })}</p>
 
-<div class="flex gap-1 overflow-x-auto pb-1">
-	<div class="text-otodb-content-fainter grid grid-rows-[1rem_repeat(7,0.75rem)] gap-[3px] text-xs">
-		<span></span>
-		{#each weekdayLabels as label, row (row)}
-			<span class="flex items-center pr-1 leading-none">{label}</span>
-		{/each}
-	</div>
-
+<div class="overflow-x-auto pb-1">
 	<div
-		class="grid [grid-auto-columns:0.75rem] grid-flow-col grid-rows-[1rem_repeat(7,0.75rem)] gap-[3px]"
+		class="grid w-max [grid-auto-columns:0.75rem] grid-flow-col grid-rows-[1rem_repeat(7,0.75rem)] gap-[3px]"
 	>
 		{#each columns as column, week (week)}
 			<span class="text-otodb-content-fainter relative text-xs">

--- a/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.svelte
+++ b/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.svelte
@@ -1,10 +1,23 @@
 <script lang="ts">
 	import { m } from '$lib/paraglide/messages';
 	import { getLocale } from '$lib/paraglide/runtime';
-	import type { ProfileActivity } from './types';
 
 	interface Props {
-		activity: ProfileActivity;
+		/**
+		 * Contribution activity over a window rolling back from today. Described structurally
+		 * rather than pulled from `$lib/schema` so the component only depends on the shape it
+		 * actually renders, and the API is free to grow fields around it.
+		 */
+		activity: {
+			/** First day of the window, `YYYY-MM-DD` (UTC). */
+			start: string;
+			/** Last day of the window, `YYYY-MM-DD` (UTC). Typically today. */
+			end: string;
+			/** Sum of every `days[].count`. */
+			total: number;
+			/** Ascending by date. Days with no contributions are omitted. */
+			days: { date: string; count: number }[];
+		};
 	}
 
 	const { activity }: Props = $props();
@@ -95,6 +108,13 @@
 
 <style>
 	.cell {
+		/*
+		 * The theme's accent, desaturated: at full chroma a wall of 365 tiles is far louder
+		 * than a "currently selected" accent is meant to be. Keeping the hue and lightness
+		 * means the heatmap still reads as part of the active theme.
+		 */
+		--tile: oklch(from var(--otodb-color-highlight-primary) l calc(c * 0.55) h);
+
 		/* A hairline keeps empty days visible against the surrounding `bg-faint` panel. */
 		outline: 1px solid color-mix(in oklab, var(--otodb-color-content-fainter) 20%, transparent);
 		outline-offset: -1px;
@@ -103,16 +123,16 @@
 			background-color: var(--otodb-color-bg-faint);
 		}
 		&[data-level='1'] {
-			background-color: color-mix(in oklab, green 25%, var(--otodb-color-bg-faint));
+			background-color: color-mix(in oklab, var(--tile) 25%, var(--otodb-color-bg-faint));
 		}
 		&[data-level='2'] {
-			background-color: color-mix(in oklab, green 45%, var(--otodb-color-bg-faint));
+			background-color: color-mix(in oklab, var(--tile) 45%, var(--otodb-color-bg-faint));
 		}
 		&[data-level='3'] {
-			background-color: color-mix(in oklab, green 70%, var(--otodb-color-bg-faint));
+			background-color: color-mix(in oklab, var(--tile) 70%, var(--otodb-color-bg-faint));
 		}
 		&[data-level='4'] {
-			background-color: color-mix(in oklab, green 95%, var(--otodb-color-bg-faint));
+			background-color: color-mix(in oklab, var(--tile) 95%, var(--otodb-color-bg-faint));
 		}
 	}
 </style>

--- a/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.svelte
+++ b/frontend/src/lib/ActivityHeatmap/ActivityHeatmap.svelte
@@ -20,18 +20,15 @@
 
 	/** Every date the component handles is a UTC midnight timestamp of an ISO `YYYY-MM-DD`. */
 	const parseDay = (date: string) => Date.parse(`${date}T00:00:00Z`);
-	const formatDay = (time: number) => new Date(time).toISOString().slice(0, 10);
 
 	const startTime = $derived(parseDay(activity.start));
 	const endTime = $derived(parseDay(activity.end));
 
 	/** Pad back to the Sunday on or before `start` so every column is a full week. */
 	const gridStartTime = $derived(startTime - new Date(startTime).getUTCDay() * MS_PER_DAY);
-	const weeks = $derived(
-		Math.max(1, Math.ceil(((endTime - gridStartTime) / MS_PER_DAY + 1) / DAYS_PER_WEEK))
-	);
+	const weeks = $derived(Math.ceil(((endTime - gridStartTime) / MS_PER_DAY + 1) / DAYS_PER_WEEK));
 
-	const counts = $derived(new Map(activity.days.map(({ date, count }) => [date, count])));
+	const counts = $derived(new Map(activity.days.map(({ date, count }) => [parseDay(date), count])));
 	const maxCount = $derived(activity.days.reduce((max, { count }) => Math.max(max, count), 0));
 
 	const level = (count: number) => {
@@ -56,32 +53,30 @@
 		)
 	);
 
-	type Cell = { date: string; count: number; label: string } | null;
+	type Cell = { count: number; label: string } | null;
 
 	const columns: { month: string; cells: Cell[] }[] = $derived.by(() => {
 		const result: { month: string; cells: Cell[] }[] = [];
 		let labelledMonth = -1;
 
 		for (let week = 0; week < weeks; week++) {
+			const weekStart = gridStartTime + week * DAYS_PER_WEEK * MS_PER_DAY;
 			const cells = Array.from({ length: DAYS_PER_WEEK }, (_, row): Cell => {
-				const time = gridStartTime + (week * DAYS_PER_WEEK + row) * MS_PER_DAY;
+				const time = weekStart + row * MS_PER_DAY;
 				// Days before `start` (the leading pad) and after `end` are rendered as gaps.
 				if (time < startTime || time > endTime) return null;
 
-				const date = formatDay(time);
-				const count = counts.get(date) ?? 0;
+				const count = counts.get(time) ?? 0;
 				return {
-					date,
 					count,
 					label: m.warm_still_marmot_reflect({ count, date: dayFormat.format(time) })
 				};
 			});
 
 			// A column carries a month label the first time that month appears along the top.
-			const first = cells.find((cell) => cell !== null);
-			const time = first ? parseDay(first.date) : 0;
-			const monthIndex = first ? new Date(time).getUTCMonth() : labelledMonth;
-			const month = monthIndex === labelledMonth ? '' : monthFormat.format(time);
+			const first = Math.max(weekStart, startTime);
+			const monthIndex = first <= endTime ? new Date(first).getUTCMonth() : labelledMonth;
+			const month = monthIndex === labelledMonth ? '' : monthFormat.format(first);
 			labelledMonth = monthIndex;
 
 			result.push({ month, cells });

--- a/frontend/src/lib/ActivityHeatmap/types.ts
+++ b/frontend/src/lib/ActivityHeatmap/types.ts
@@ -1,7 +1,4 @@
 import type { components } from '$lib/schema';
 
-/** A single UTC day of the contribution heatmap. */
-export type ActivityDay = components['schemas']['ActivityDaySchema'];
-
 /** A user's contribution activity over a rolling 365-day window. */
 export type ProfileActivity = components['schemas']['ProfileActivitySchema'];

--- a/frontend/src/lib/ActivityHeatmap/types.ts
+++ b/frontend/src/lib/ActivityHeatmap/types.ts
@@ -1,4 +1,0 @@
-import type { components } from '$lib/schema';
-
-/** A user's contribution activity over a rolling 365-day window. */
-export type ProfileActivity = components['schemas']['ProfileActivitySchema'];

--- a/frontend/src/lib/ActivityHeatmap/types.ts
+++ b/frontend/src/lib/ActivityHeatmap/types.ts
@@ -1,0 +1,7 @@
+import type { components } from '$lib/schema';
+
+/** A single UTC day of the contribution heatmap. */
+export type ActivityDay = components['schemas']['ActivityDaySchema'];
+
+/** A user's contribution activity over a rolling 365-day window. */
+export type ProfileActivity = components['schemas']['ProfileActivitySchema'];

--- a/frontend/src/routes/profile/[username]/+page.server.ts
+++ b/frontend/src/routes/profile/[username]/+page.server.ts
@@ -5,7 +5,7 @@ import { ModelsWithComments } from '$lib/schema';
 export const load: PageServerLoad = async ({ fetch, parent, params }) => {
 	const data = await parent();
 
-	const [{ data: connections }, { data: comments }] = await Promise.all([
+	const [{ data: connections }, { data: comments }, { data: activity }] = await Promise.all([
 		client.GET('/api/profile/connection', {
 			fetch,
 			params: {
@@ -22,8 +22,16 @@ export const load: PageServerLoad = async ({ fetch, parent, params }) => {
 					pk: data.profile.id
 				}
 			}
+		}),
+		client.GET('/api/profile/activity', {
+			fetch,
+			params: {
+				query: {
+					username: params.username
+				}
+			}
 		})
 	]);
 
-	return { comments, connections };
+	return { activity, comments, connections };
 };

--- a/frontend/src/routes/profile/[username]/+page.svelte
+++ b/frontend/src/routes/profile/[username]/+page.svelte
@@ -2,6 +2,7 @@
 	import Section from '$lib/Section.svelte';
 
 	import { m } from '$lib/paraglide/messages.js';
+	import ActivityHeatmap from '$lib/ActivityHeatmap/ActivityHeatmap.svelte';
 	import CommentTree from '$lib/CommentTree/CommentTree.svelte';
 	import Connections from '$lib/Connections.svelte';
 	import { getVersionKey, versions } from '$lib/enums/version';
@@ -51,6 +52,12 @@
 		<Connections items={data.connections} map={profileConnectionMap} />
 	{/if}
 </Section>
+
+{#if data.activity}
+	<Section title={m.brave_deep_falcon_soar()}>
+		<ActivityHeatmap activity={data.activity} />
+	</Section>
+{/if}
 
 <Section title={m.same_broad_haddock_pinch()}>
 	<CommentTree

--- a/frontend/src/routes/profile/[username]/page.stories.ts
+++ b/frontend/src/routes/profile/[username]/page.stories.ts
@@ -105,18 +105,18 @@ const comments = [
 ];
 
 /**
- * A fixed 365-day window (`start` = `end` − 364), so the heatmap renders identically on
- * every run instead of following the current date. `ActivityHeatmap.stories.ts` covers what
- * a full year looks like; here only the section needs to show up.
+ * A fixed stand-in for the window rolling back from today (`start` = `end` − 364), so the
+ * heatmap renders identically on every run. `ActivityHeatmap.stories.ts` covers what a busy
+ * year looks like; here only the section needs to show up.
  */
 const activity = {
-	start: '2025-01-01',
-	end: '2025-12-31',
+	start: '2025-08-08',
+	end: '2026-08-07',
 	total: 9,
 	days: [
-		{ date: '2025-03-04', count: 1 },
-		{ date: '2025-07-19', count: 5 },
-		{ date: '2025-11-28', count: 3 }
+		{ date: '2025-10-04', count: 1 },
+		{ date: '2026-02-19', count: 5 },
+		{ date: '2026-06-28', count: 3 }
 	]
 };
 

--- a/frontend/src/routes/profile/[username]/page.stories.ts
+++ b/frontend/src/routes/profile/[username]/page.stories.ts
@@ -105,35 +105,20 @@ const comments = [
 ];
 
 /**
- * A fixed 365-day window (`start` = `end` − 364) with deterministic per-day counts, so the
- * heatmap renders identically on every run instead of following the current date.
+ * A fixed 365-day window (`start` = `end` − 364), so the heatmap renders identically on
+ * every run instead of following the current date. `ActivityHeatmap.stories.ts` covers what
+ * a full year looks like; here only the section needs to show up.
  */
-const activity = (() => {
-	const MS_PER_DAY = 86_400_000;
-	const start = '2025-01-01';
-	const startTime = Date.parse(`${start}T00:00:00Z`);
-
-	const days = [];
-	let total = 0;
-
-	for (let index = 0; index < 365; index++) {
-		let x = Math.imul(index + 1, 2654435761);
-		x ^= x >>> 15;
-		x = Math.imul(x, 2246822519);
-		x ^= x >>> 13;
-		const value = (x >>> 0) / 4294967296;
-
-		if (value < 0.35) continue;
-		const count = 1 + Math.floor(value * 9);
-		days.push({
-			date: new Date(startTime + index * MS_PER_DAY).toISOString().slice(0, 10),
-			count
-		});
-		total += count;
-	}
-
-	return { start, end: '2025-12-31', total, days };
-})();
+const activity = {
+	start: '2025-01-01',
+	end: '2025-12-31',
+	total: 9,
+	days: [
+		{ date: '2025-03-04', count: 1 },
+		{ date: '2025-07-19', count: 5 },
+		{ date: '2025-11-28', count: 3 }
+	]
+};
 
 const baseData = {
 	stats,

--- a/frontend/src/routes/profile/[username]/page.stories.ts
+++ b/frontend/src/routes/profile/[username]/page.stories.ts
@@ -104,6 +104,37 @@ const comments = [
 	}
 ];
 
+/**
+ * A fixed 365-day window (`start` = `end` − 364) with deterministic per-day counts, so the
+ * heatmap renders identically on every run instead of following the current date.
+ */
+const activity = (() => {
+	const MS_PER_DAY = 86_400_000;
+	const start = '2025-01-01';
+	const startTime = Date.parse(`${start}T00:00:00Z`);
+
+	const days = [];
+	let total = 0;
+
+	for (let index = 0; index < 365; index++) {
+		let x = Math.imul(index + 1, 2654435761);
+		x ^= x >>> 15;
+		x = Math.imul(x, 2246822519);
+		x ^= x >>> 13;
+		const value = (x >>> 0) / 4294967296;
+
+		if (value < 0.35) continue;
+		const count = 1 + Math.floor(value * 9);
+		days.push({
+			date: new Date(startTime + index * MS_PER_DAY).toISOString().slice(0, 10),
+			count
+		});
+		total += count;
+	}
+
+	return { start, end: '2025-12-31', total, days };
+})();
+
 const baseData = {
 	stats,
 	links: linksWithoutEdit,
@@ -111,7 +142,8 @@ const baseData = {
 	profile: memberProfile,
 	user: null,
 	connections: [],
-	comments: []
+	comments: [],
+	activity
 };
 
 const meta = {


### PR DESCRIPTION
Part 2 of a two-PR stack for #981, stacked on #991. Please review #991 first.

close #981

Renders a GitHub-style 365-day contribution heatmap on `/profile/[username]`, between the profile info section and the comments section, from the `/api/profile/activity` endpoint added in #991.

### `ActivityHeatmap`

- Builds its grid purely from the `start`/`end` dates in its props — no `new Date()`, `Date.now()` or `Math.random()` — so its stories render identically on every run.
- The endpoint reports only the days that had activity and leaves the five-level bucketing to the client, so levels are derived here relative to the busiest day in the window.
- Cells are coloured by mixing green into `--otodb-color-bg-faint` the same way `--otodb-color-ins` already does, so the scale works across all seven themes. Level-0 cells get a hairline outline so they stay visible against the section panel.
- Month, weekday and tooltip labels go through `Intl.DateTimeFormat(getLocale(), …)` like `Time.svelte` does.
- The week starts on Sunday, following GitHub. The leading padding before `start` and the trailing days after `end` render as gaps rather than level-0 cells.

### Data

The page load fetches the endpoint through the generated client alongside the existing connection and comment requests.

### Stories

- `ActivityHeatmap.stories.ts` — dense, sparse and high-outlier years, all from fixed dates and a seeded pattern.
- The `/profile/[username]` page story gains a fixed-date `activity` object.

Verified with `bun run format`, `bun run lint`, `bun run check`, the Storybook vitest project, and visual checks across all 7 themes × 4 locales.
