### PR TITLE
Add a `/stats/works` page charting the cumulative work count by month

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -453,5 +453,8 @@
 	"bold_keen_otter_vault": "Rollback to before this revision",
 	"tame_swift_heron_plead": "Rollback ALL revisions made by {username} to before {label}?",
 	"hazy_calm_otter_dream": "Plain Dark",
-	"misty_plain_finch_glow": "Plain Light"
+	"misty_plain_finch_glow": "Plain Light",
+	"proud_bold_gecko_thrive": "Works over time",
+	"mellow_zesty_stork_bloom": "The number of works in the database at the end of each month.",
+	"sunny_smug_walrus_lift": "{total} works at the end of {month}"
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -318,5 +318,8 @@
 	"bold_keen_otter_vault": "この変更より前にロールバック",
 	"tame_swift_heron_plead": "{username} のすべての変更を {label} より前にロールバックしますか？",
 	"hazy_calm_otter_dream": "無地（ダーク）",
-	"misty_plain_finch_glow": "無地（ライト）"
+	"misty_plain_finch_glow": "無地（ライト）",
+	"proud_bold_gecko_thrive": "作品数の推移",
+	"mellow_zesty_stork_bloom": "各月末時点でデータベースに登録されていた作品の数です。",
+	"sunny_smug_walrus_lift": "{month}末時点で{total}件"
 }

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -318,5 +318,8 @@
 	"bold_keen_otter_vault": "이 변경 이전으로 롤백",
 	"tame_swift_heron_plead": "{username}님의 모든 변경을 {label} 이전으로 롤백하시겠습니까?",
 	"hazy_calm_otter_dream": "무지 다크",
-	"misty_plain_finch_glow": "무지 라이트"
+	"misty_plain_finch_glow": "무지 라이트",
+	"proud_bold_gecko_thrive": "작품 수 추이",
+	"mellow_zesty_stork_bloom": "각 월말 기준 데이터베이스에 등록된 작품 수입니다.",
+	"sunny_smug_walrus_lift": "{month} 말 기준 {total}건"
 }

--- a/frontend/messages/zh-cn.json
+++ b/frontend/messages/zh-cn.json
@@ -319,5 +319,8 @@
 	"bold_keen_otter_vault": "回滚到此更改之前",
 	"tame_swift_heron_plead": "将 {username} 的所有更改回滚到 {label} 之前？",
 	"hazy_calm_otter_dream": "素色深色",
-	"misty_plain_finch_glow": "素色浅色"
+	"misty_plain_finch_glow": "素色浅色",
+	"proud_bold_gecko_thrive": "作品数变化",
+	"mellow_zesty_stork_bloom": "每月月末数据库中收录的作品数量。",
+	"sunny_smug_walrus_lift": "{month} 月末为 {total} 件"
 }

--- a/frontend/src/lib/GlobalSideNav/GlobalSideNav.svelte
+++ b/frontend/src/lib/GlobalSideNav/GlobalSideNav.svelte
@@ -97,6 +97,9 @@
 			{@render link('/profile', m.bright_nimble_eagle_glide())}
 			{@render link('/wiki/faq', 'FAQ')}
 			{@render link('/work/random', m.fuzzy_chunky_niklas_peek())}
+			<!-- The statistics panel below, which links to the same page, is desktop-only,
+			     so this entry is the only way to reach it on a narrow screen. -->
+			{@render link('/stats/works', m.white_helpful_lion_rise())}
 		</ul>
 	</div>
 	<div
@@ -179,7 +182,7 @@
 		class="md:border-otodb-content-faint md:bg-otodb-bg-faint/75 mt-8 hidden md:mt-0 md:block md:border md:px-3 md:py-2"
 	>
 		<div class="border-otodb-content-faint mb-2 border-b text-xs">
-			{m.white_helpful_lion_rise()}
+			<a href="/stats/works" class="no-underline">{m.white_helpful_lion_rise()}</a>
 		</div>
 		<div class="flex justify-between">
 			<span>{m.grand_merry_fly_succeed()}</span><span>{stats.works}</span>

--- a/frontend/src/lib/stats/BarChart.stories.ts
+++ b/frontend/src/lib/stats/BarChart.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import type { ComponentProps } from 'svelte';
+import BarChart from './BarChart.svelte';
+import type { ChartBar } from './history';
+
+/** A rising series shaped like a cumulative count, one bar per month. */
+const cumulative = (months: number, monthly: number): ChartBar[] =>
+	Array.from({ length: months }, (_, i) => {
+		const value = (i + 1) * monthly;
+		return {
+			value,
+			label: i % 12 === 0 ? String(2019 + Math.floor(i / 12)) : undefined,
+			title: `${value} works`
+		};
+	});
+
+const meta = {
+	component: BarChart,
+	args: {
+		bars: cumulative(90, 220),
+		ariaLabel: 'Works over time'
+	}
+} satisfies Meta<ComponentProps<typeof BarChart>>;
+
+export default meta;
+type Story = StoryObj<ComponentProps<typeof BarChart>>;
+
+/** The density the `/stats/works` page renders at: several years of monthly bars. */
+export const Default: Story = {};
+
+/** Few enough bars that each one is wide, which is how a single year reads. */
+export const Sparse: Story = {
+	args: {
+		bars: cumulative(12, 180)
+	}
+};
+
+/** Small values, where the axis has to pick a step of a few units rather than hundreds. */
+export const SmallValues: Story = {
+	args: {
+		bars: cumulative(12, 1)
+	}
+};

--- a/frontend/src/lib/stats/BarChart.svelte
+++ b/frontend/src/lib/stats/BarChart.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { niceTicks, type ChartBar } from './history';
+
+	let { bars, ariaLabel }: { bars: ChartBar[]; ariaLabel: string } = $props();
+
+	// One SVG user unit is one CSS pixel: the viewBox width follows the element's own
+	// width instead of being fixed, so the axis text keeps its 12px size at every
+	// container width rather than shrinking with the chart. Nothing has been laid out
+	// yet when the server renders — and the first client render matches it — so the
+	// fallback is what SSR and Storybook draw before the measurement lands.
+	const FALLBACK_WIDTH = 1000;
+	const HEIGHT = 220;
+	const PAD = { top: 8, right: 8, bottom: 22, left: 56 };
+	const plotHeight = HEIGHT - PAD.top - PAD.bottom;
+
+	let measuredWidth = $state(0);
+	const width = $derived(measuredWidth || FALLBACK_WIDTH);
+	const plotWidth = $derived(width - PAD.left - PAD.right);
+
+	const ticks = $derived(niceTicks(Math.max(0, ...bars.map((b) => b.value))));
+	const ceiling = $derived(ticks[ticks.length - 1]);
+
+	const slot = $derived(plotWidth / Math.max(1, bars.length));
+	const barWidth = $derived(Math.max(1, slot * 0.8));
+
+	const y = (value: number) => PAD.top + plotHeight - (value / ceiling) * plotHeight;
+	const x = (index: number) => PAD.left + index * slot + (slot - barWidth) / 2;
+</script>
+
+<div bind:clientWidth={measuredWidth} class="w-full">
+	<svg
+		viewBox="0 0 {width} {HEIGHT}"
+		height={HEIGHT}
+		class="text-otodb-content-primary block w-full"
+		role="img"
+		aria-label={ariaLabel}
+	>
+		{#each ticks as tick (tick)}
+			<line
+				x1={PAD.left}
+				x2={width - PAD.right}
+				y1={y(tick)}
+				y2={y(tick)}
+				stroke="currentColor"
+				stroke-width="1"
+				opacity="0.25"
+			/>
+			<text
+				x={PAD.left - 8}
+				y={y(tick) + 4}
+				text-anchor="end"
+				font-size="12"
+				fill="currentColor"
+				opacity="0.7">{tick}</text
+			>
+		{/each}
+
+		{#each bars as bar, i (i)}
+			<rect
+				x={x(i)}
+				y={y(bar.value)}
+				width={barWidth}
+				height={PAD.top + plotHeight - y(bar.value)}
+				class="fill-otodb-highlight-primary"
+			>
+				<title>{bar.title}</title>
+			</rect>
+			{#if bar.label}
+				<text
+					x={x(i) + barWidth / 2}
+					y={HEIGHT - 6}
+					text-anchor="middle"
+					font-size="12"
+					fill="currentColor"
+					opacity="0.7">{bar.label}</text
+				>
+			{/if}
+		{/each}
+	</svg>
+</div>

--- a/frontend/src/lib/stats/history.test.ts
+++ b/frontend/src/lib/stats/history.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { bucketByMonth, niceTicks } from './history';
+
+describe('bucketByMonth', () => {
+	it('returns nothing for an empty series', () => {
+		expect(bucketByMonth([])).toEqual([]);
+	});
+
+	it('keeps the last running total of each month', () => {
+		const actual = bucketByMonth([
+			{ date: '2024-01-03', total: 2 },
+			{ date: '2024-01-20', total: 5 },
+			{ date: '2024-02-01', total: 6 }
+		]);
+
+		expect(actual).toEqual([
+			{ month: '2024-01', total: 5 },
+			{ month: '2024-02', total: 6 }
+		]);
+	});
+
+	it('fills months with no additions, carrying the running total', () => {
+		const actual = bucketByMonth([
+			{ date: '2024-01-03', total: 4 },
+			{ date: '2024-04-10', total: 5 }
+		]);
+
+		expect(actual).toEqual([
+			{ month: '2024-01', total: 4 },
+			{ month: '2024-02', total: 4 },
+			{ month: '2024-03', total: 4 },
+			{ month: '2024-04', total: 5 }
+		]);
+	});
+
+	it('rolls over into the next year', () => {
+		const actual = bucketByMonth([
+			{ date: '2023-12-31', total: 1 },
+			{ date: '2024-01-01', total: 2 }
+		]);
+
+		expect(actual.map((b) => b.month)).toEqual(['2023-12', '2024-01']);
+	});
+});
+
+describe('niceTicks', () => {
+	it('starts at zero and ends at or above the maximum', () => {
+		const ticks = niceTicks(1234);
+
+		expect(ticks[0]).toBe(0);
+		expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(1234);
+	});
+
+	it('uses a round step', () => {
+		expect(niceTicks(1000)).toEqual([0, 250, 500, 750, 1000]);
+		expect(niceTicks(8)).toEqual([0, 2, 4, 6, 8]);
+	});
+
+	it('never collapses to a single zero tick', () => {
+		expect(niceTicks(0)).toEqual([0, 1]);
+	});
+});

--- a/frontend/src/lib/stats/history.ts
+++ b/frontend/src/lib/stats/history.ts
@@ -1,0 +1,72 @@
+/** One day on which at least one work was added, and the total it left behind. */
+export type WorkHistoryPoint = {
+	/** `YYYY-MM-DD`, in UTC. */
+	date: string;
+	/** Works in the database at the end of that day. */
+	total: number;
+};
+
+export type MonthlyBucket = {
+	/** `YYYY-MM`. */
+	month: string;
+	/** Works in the database at the end of the month. */
+	total: number;
+};
+
+const monthOf = (date: string) => date.slice(0, 7);
+
+const nextMonth = (month: string) => {
+	const year = Number(month.slice(0, 4));
+	const m = Number(month.slice(5, 7));
+	return m === 12 ? `${year + 1}-01` : `${year}-${String(m + 1).padStart(2, '0')}`;
+};
+
+/**
+ * Collapse the daily series into one bucket per month, filling in the months
+ * where nothing was added so the bars stay evenly spaced in time. The running
+ * total is carried across those empty months rather than dropping to zero.
+ *
+ * `points` must be ascending, which the endpoint guarantees.
+ */
+export function bucketByMonth(points: WorkHistoryPoint[]): MonthlyBucket[] {
+	if (points.length === 0) return [];
+
+	const last = monthOf(points[points.length - 1].date);
+
+	const buckets: MonthlyBucket[] = [];
+	let carried = 0;
+	let i = 0;
+	for (let month = monthOf(points[0].date); month <= last; month = nextMonth(month)) {
+		while (i < points.length && monthOf(points[i].date) === month) carried = points[i++].total;
+		buckets.push({ month, total: carried });
+	}
+	return buckets;
+}
+
+/** One bar of `BarChart.svelte`. */
+export type ChartBar = {
+	value: number;
+	/** Drawn under the bar. Left out for bars that would crowd the axis. */
+	label?: string;
+	/** Hover/assistive text for the bar. */
+	title: string;
+};
+
+/**
+ * Tick values from zero to at least `max`, on a round step. The last tick is the
+ * top of the chart's value axis, so it is always greater than zero.
+ */
+export function niceTicks(max: number): number[] {
+	const safeMax = Math.max(1, max);
+	const raw = safeMax / 4;
+	const magnitude = 10 ** Math.floor(Math.log10(raw));
+	// The last candidate is always >= raw, so `find` always hits. Rounded so the step
+	// stays a whole number of works; under a magnitude of one every candidate rounds
+	// away and the floor of 1 takes over.
+	const candidates = [1, 2, 2.5, 5, 10].map((m) => m * magnitude);
+	const step = Math.max(1, Math.round(candidates.find((s) => s >= raw) ?? magnitude));
+
+	const ticks: number[] = [];
+	for (let v = 0; v <= Math.ceil(safeMax / step) * step; v += step) ticks.push(v);
+	return ticks;
+}

--- a/frontend/src/routes/stats/works/+page.server.ts
+++ b/frontend/src/routes/stats/works/+page.server.ts
@@ -1,0 +1,12 @@
+import client from '$lib/api.server';
+import { m } from '$lib/paraglide/messages';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	const { data: history } = await client.GET('/api/stats/works/history', { fetch });
+
+	return {
+		history,
+		head: { title: m.proud_bold_gecko_thrive() }
+	};
+};

--- a/frontend/src/routes/stats/works/+page.svelte
+++ b/frontend/src/routes/stats/works/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { m } from '$lib/paraglide/messages.js';
+	import Section from '$lib/Section.svelte';
+	import BarChart from '$lib/stats/BarChart.svelte';
+	import { bucketByMonth, type ChartBar } from '$lib/stats/history';
+
+	let { data } = $props();
+
+	const buckets = $derived(bucketByMonth(data.history));
+
+	// Years span a dozen bars each, so labelling every month would be unreadable:
+	// only January carries a label, plus the first bucket when the series starts
+	// partway through a year.
+	const bars = $derived(
+		buckets.map(({ month, total }, i): ChartBar => {
+			const [year, monthOfYear] = month.split('-');
+			return {
+				value: total,
+				label: i === 0 || monthOfYear === '01' ? year : undefined,
+				title: m.sunny_smug_walrus_lift({ total, month })
+			};
+		})
+	);
+</script>
+
+<Section title={m.proud_bold_gecko_thrive()}>
+	<p class="mb-4">{m.mellow_zesty_stork_bloom()}</p>
+	<BarChart {bars} ariaLabel={m.proud_bold_gecko_thrive()} />
+</Section>

--- a/frontend/src/routes/stats/works/page.stories.ts
+++ b/frontend/src/routes/stats/works/page.stories.ts
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import type { ComponentProps } from 'svelte';
+import { m } from '$lib/paraglide/messages.js';
+import { Levels } from '$lib/schema';
+import type { WorkHistoryPoint } from '$lib/stats/history';
+import Page from './+page.svelte';
+
+const stats = { works: 19_000, tags: 4_300, songs: 8_100, lists: 260 };
+
+const head = { title: m.proud_bold_gecko_thrive() };
+
+const memberUser = {
+	csrf: 'csrf-token',
+	user_id: '1',
+	username: 'member_user',
+	level: Levels.Member,
+	prefs: {
+		THEME: 0,
+		VIDEO_PLATFORM: 0,
+		PREFER_AUTHOR_UPLOAD: false
+	},
+	notifs_count: 0,
+	notifs_nonsub_count: 0
+};
+
+/**
+ * A 32-bit xorshift, so the fixture is the same on every open: the story is meant
+ * to be usable as a visual regression baseline, which rules out `Math.random()`.
+ */
+const xorshift = (seed: number) => () => {
+	seed ^= seed << 13;
+	seed ^= seed >>> 17;
+	seed ^= seed << 5;
+	return (seed >>> 0) / 4_294_967_296;
+};
+
+const DAY = 24 * 60 * 60 * 1000;
+const FIRST_DAY = Date.parse('2019-01-01T00:00:00Z');
+const DAYS = 2738; // through 2026-06-30
+
+/**
+ * The shape the real endpoint returns: ascending, sparse (quiet days are left out),
+ * and with a submission rate that climbs as the site grows.
+ */
+const history: WorkHistoryPoint[] = [];
+const random = xorshift(20260807);
+let total = 0;
+for (let day = 0; day < DAYS; day++) {
+	const added = Math.floor(random() * (5 + day / 150));
+	if (added === 0) continue;
+	total += added;
+	history.push({ date: new Date(FIRST_DAY + day * DAY).toISOString().slice(0, 10), total });
+}
+
+const meta = {
+	component: Page,
+	args: {
+		data: {
+			stats,
+			head,
+			user: memberUser,
+			history
+		}
+	}
+} satisfies Meta<ComponentProps<typeof Page>>;
+
+export default meta;
+type Story = StoryObj<ComponentProps<typeof Page>>;
+
+/** Seven and a half years of submissions, one bar per month. */
+export const Default: Story = {};


### PR DESCRIPTION
close #982

Adds a `/stats/works` page that charts how many works the database holds over time. Stacked on #989, which adds the endpoint it reads.

Frontend only — no backend files in this PR.

## What's here

- `src/lib/stats/history.ts` — the response types plus `bucketByMonth()`, which collapses the sparse daily series the API returns into one bucket per month (carrying the running total across months with no additions, rather than letting them drop to zero), and `niceTicks()` for the value axis. Unit-tested in `history.test.ts`.
- `src/lib/stats/BarChart.svelte` — a hand-rolled SVG bar chart. No charting dependency was added: the chart needs gridlines, bars and labels, and that is cheaper to write than to configure. The viewBox width tracks the element's own width so one SVG unit is one CSS pixel and the axis text keeps its size on narrow screens.
- `src/routes/stats/works/` — the page itself, one bar per month, labelled by year.
- `GlobalSideNav.svelte` — the desktop "Database Statistics" heading now links to the page, and a nav entry was added to the main list so the page is reachable on mobile too, where that panel is hidden.

## Stories

- `src/routes/stats/works/page.stories.ts` — the page with seven and a half years of submissions. The fixture is generated from a seeded xorshift rather than `Math.random()`, so the story renders identically on every open.
- `src/lib/stats/BarChart.stories.ts` — the chart on its own, at different bar densities, value magnitudes and heights.

## Checks

`bun run format`, `bun run lint`, `bun run check`, `bun run test` and `bun run test-storybook` all pass.

## Later

The `/stats/works.png` idea from #982 is not here — this is the ordinary page. The chart is already inline SVG driven by the same data, so serving it as an image is a follow-up rather than a rewrite.
