### PR TITLE
Add `GET /api/stats/works/history` for the works-over-time chart

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5883,6 +5883,37 @@
         },
         "deprecated": false
       }
+    },
+    "/api/stats/works/history": {
+      "get": {
+        "summary": "WorkHistory",
+        "operationId": "ApiStatsWorksHistoryWorkHistory",
+        "responses": {
+          "200": {
+            "description": "Request fulfilled, document follows",
+            "headers": {
+              "cache-control": {
+                "schema": {
+                  "type": "string"
+                },
+                "required": false,
+                "deprecated": false
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkHistoryPoint"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
     }
   },
   "components": {
@@ -10944,6 +10975,23 @@
         ],
         "title": "ModerationEventType",
         "type": "integer"
+      },
+      "WorkHistoryPoint": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "total": {
+            "type": "integer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "total"
+        ],
+        "title": "WorkHistoryPoint"
       }
     },
     "securitySchemes": {

--- a/backend/otodb_next/app.py
+++ b/backend/otodb_next/app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import datetime
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -56,6 +58,37 @@ async def statistics(db_session: AsyncSession) -> tuple[int, int, int, int]:
 	return tuple(result.one())
 
 
+@dataclass
+class WorkHistoryPoint:
+	"""Works in the database at the end of one UTC day."""
+
+	date: datetime.date
+	total: int
+
+
+# The data has daily granularity, so one hour of cache staleness is not visible.
+@get('/stats/works/history', cache=3600, cache_control=CacheControlHeader(max_age=3600))
+async def work_history(db_session: AsyncSession) -> list[WorkHistoryPoint]:
+	"""Works total at the end of each UTC day, ascending. Quiet days get no point.
+
+	The query excludes merged works (`moved_to`). Thus the last total agrees with
+	`/api/stats`, but a merge also decreases the totals of past days.
+	"""
+	# `AT TIME ZONE 'UTC'` pins the day boundary; a bare `::date` obeys the session
+	# TimeZone. `::int` prevents a `Decimal` from the window sum.
+	query = text("""
+		SELECT
+			(created_at AT TIME ZONE 'UTC')::date,
+			SUM(COUNT(*)) OVER (ORDER BY (created_at AT TIME ZONE 'UTC')::date)::int
+		FROM otodb_mediawork
+		WHERE moved_to_id IS NULL
+		GROUP BY 1
+		ORDER BY 1;
+	""")
+	result = await db_session.execute(query)
+	return [WorkHistoryPoint(*row) for row in result]
+
+
 class Base(DeclarativeBase): ...
 
 
@@ -74,7 +107,7 @@ jobs = [
 	Job('moderation sweep', interval=15 * 60, run=prune_expired),
 ]
 
-api = Router(path='/api', route_handlers=[statistics])
+api = Router(path='/api', route_handlers=[statistics, work_history])
 app = Litestar(
 	route_handlers=[api],
 	cors_config=cors_config,

--- a/backend/tests/otodb_next/test_GET_stats_works_history.py
+++ b/backend/tests/otodb_next/test_GET_stats_works_history.py
@@ -1,0 +1,98 @@
+"""Tests for GET /api/stats/works/history endpoint."""
+
+import datetime
+
+import psycopg
+import pytest
+from django.db import connection
+from litestar import Router
+from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
+from litestar.testing import create_test_client
+
+from otodb.models.enums import Status
+from otodb_next.app import work_history
+
+
+def _dsn() -> str:
+	s = connection.settings_dict
+	return (
+		f'host={s["HOST"]} port={s["PORT"]} dbname={s["NAME"]}'
+		f' user={s["USER"]} password={s["PASSWORD"]}'
+	)
+
+
+@pytest.fixture
+def client(db):
+	"""The endpoint, connected to the pytest database.
+
+	The app builds its engine from settings at import time, so that engine points
+	at the development database. The test supplies its own engine. Its session
+	runs in Asia/Tokyo on purpose: the query must pin the UTC day boundary itself.
+	"""
+	s = connection.settings_dict
+	config = SQLAlchemyAsyncConfig(
+		connection_string=(
+			f'postgresql+psycopg://{s["USER"]}:{s["PASSWORD"]}'
+			f'@{s["HOST"]}:{s["PORT"]}/{s["NAME"]}'
+			'?options=-c%20timezone%3DAsia/Tokyo'
+		),
+		create_all=False,
+	)
+	with create_test_client(
+		route_handlers=[Router(path='/api', route_handlers=[work_history])],
+		plugins=[SQLAlchemyPlugin(config)],
+	) as client:
+		yield client
+
+
+@pytest.fixture
+def works(db):
+	"""Committed works, inserted with plain psycopg.
+
+	The endpoint reads on its own connection and cannot see rows inside the test
+	transaction. The fixture commits the rows and deletes them again by hand.
+	This avoids `transactional_db`, whose truncation breaks the tests that follow.
+	"""
+	with psycopg.connect(_dsn(), autocommit=True) as conn:
+
+		def work(created_at: str, moved_to: int | None = None) -> int:
+			row = conn.execute(
+				'INSERT INTO otodb_mediawork (rating, status, created_at, moved_to_id)'
+				' VALUES (0, %s, %s, %s) RETURNING id',
+				(
+					Status.APPROVED,
+					datetime.datetime.fromisoformat(created_at),
+					moved_to,
+				),
+			).fetchone()
+			return row[0]
+
+		kept = work('2026-03-01T01:00:00+00:00')
+		work('2026-03-01T22:00:00+00:00')
+		work('2026-03-03T23:30:00+00:00')
+		work('2026-03-04T00:30:00+00:00')
+		work('2026-03-06T12:00:00+00:00', moved_to=kept)
+	yield
+	with psycopg.connect(_dsn(), autocommit=True) as conn:
+		conn.execute('DELETE FROM otodb_mediawork')
+
+
+def test_returns_the_running_total_for_each_day_that_gained_works(client, works):
+	response = client.get('/api/stats/works/history')
+
+	assert response.status_code == 200
+	# The 2nd and the 5th gained no works, so they get no point. In Asia/Tokyo the
+	# works of the 3rd and the 4th fall on one day, but the UTC cut keeps them
+	# apart. The work that was merged into another work never appears.
+	assert response.json() == [
+		{'date': '2026-03-01', 'total': 2},
+		{'date': '2026-03-03', 'total': 3},
+		{'date': '2026-03-04', 'total': 4},
+	]
+
+
+def test_returns_an_empty_series_when_no_works_exist(client):
+	response = client.get('/api/stats/works/history')
+
+	assert response.status_code == 200
+	assert response.json() == []


### PR DESCRIPTION
Adds the endpoint that the `/stats/works` page in #988 reads. Part of #982; #988 is stacked on top of this and draws the chart.

Backend only — no frontend files in this PR.

## The endpoint

```
GET /api/stats/works/history
[{"date": "YYYY-MM-DD", "total": 1247}, ...]
```

The series is ascending and sparse: a day with no new works gets no point. `total` is the number of works at the end of that UTC day. One handler in `otodb_next/app.py`, next to the existing `/api/stats`, over a single aggregate:

```sql
SELECT
	(created_at AT TIME ZONE 'UTC')::date,
	SUM(COUNT(*)) OVER (ORDER BY (created_at AT TIME ZONE 'UTC')::date)::int
FROM otodb_mediawork
WHERE moved_to_id IS NULL
GROUP BY 1
ORDER BY 1;
```

Two casts carry weight. `AT TIME ZONE 'UTC'` pins the day boundary: a bare `::date` obeys the session `TimeZone`, and the Django and SQLAlchemy connections do not agree on it. The `::int` cast prevents a `Decimal` from the window sum, which the serializer refuses.

The `moved_to_id IS NULL` filter is the same filter as `/api/stats`, so the last point agrees with the works count in the sidebar. The trade-off: a merge also decreases the totals of past days. The series shows the current state, not a historical snapshot. The docstring says so.

The response carries only the running total. An earlier revision also had a per-day `added` count. Nothing consumes it, so it came out again; it is one `openapi.json` regeneration away if a chart wants it later.

## Caching

`cache=3600` with `Cache-Control: max-age=3600`, the same shape as `/api/stats` but with a longer TTL. The data has daily granularity, so one hour of staleness is not visible. The cache keeps the aggregate off the request path: at most one query per hour per worker, and browsers or a CDN absorb the rest. No new table, no job, no dependency — the aggregate is a single scan of `otodb_mediawork`.

## Tests

`tests/otodb_next/test_GET_stats_works_history.py` starts the route with `create_test_client` against the pytest database and sends real requests. The seed rows cover four cases: two works on one day, a pair around UTC midnight, a gap day, and a merged work. The test client's SQLAlchemy session runs in Asia/Tokyo, so a missing `AT TIME ZONE 'UTC'` fails the test. Each of these mutations fails the test: removed time zone pin, removed merge filter, per-day count instead of the running total.

The endpoint reads on its own connection and cannot see rows inside the usual test transaction. The fixture inserts committed rows with plain psycopg and deletes them again. This keeps `transactional_db` and its table truncation out of the suite.

The suite ran locally against PostgreSQL 16 (the machine has no container runtime); CI runs the pinned 17.6.

## Not covered

`otodb_tagwork` has no creation timestamp, so the tags series from #814 needs a schema change first. This PR is works only.
