### PR TITLE
Add a cached `/api/profile/activity` endpoint for the contribution heatmap

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1703,6 +1703,36 @@
         }
       }
     },
+    "/api/profile/activity": {
+      "get": {
+        "operationId": "otodb_api_profile_activity",
+        "summary": "Activity",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "username",
+            "schema": {
+              "title": "Username",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileActivitySchema"
+                }
+              }
+            }
+          }
+        },
+        "description": "Daily contribution counts (revisions, thread posts and comments) over the\nlast year, for the profile heatmap. Days with no activity are omitted."
+      }
+    },
     "/api/profile/search": {
       "get": {
         "operationId": "otodb_api_profile_search",
@@ -7616,6 +7646,58 @@
           "count"
         ],
         "title": "PagedWorkSourceSchema",
+        "type": "object"
+      },
+      "ActivityDaySchema": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "date",
+          "count"
+        ],
+        "title": "ActivityDaySchema",
+        "type": "object"
+      },
+      "ProfileActivitySchema": {
+        "properties": {
+          "start": {
+            "format": "date",
+            "title": "Start",
+            "type": "string"
+          },
+          "end": {
+            "format": "date",
+            "title": "End",
+            "type": "string"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "days": {
+            "items": {
+              "$ref": "#/components/schemas/ActivityDaySchema"
+            },
+            "title": "Days",
+            "type": "array"
+          }
+        },
+        "required": [
+          "start",
+          "end",
+          "total",
+          "days"
+        ],
+        "title": "ProfileActivitySchema",
         "type": "object"
       },
       "ProfileSearchFilterSchema": {

--- a/backend/otodb/api/profile.py
+++ b/backend/otodb/api/profile.py
@@ -1,4 +1,5 @@
 import datetime
+from collections import Counter
 from typing import List, Literal
 
 from django.core.cache import cache
@@ -101,7 +102,7 @@ def _count_per_day(
 	rows = (
 		qs.filter(**{f'{field}__gte': since, f'{field}__lt': until})
 		.order_by()
-		.annotate(day=TruncDate(field, tzinfo=datetime.timezone.utc))
+		.annotate(day=TruncDate(field, tzinfo=datetime.UTC))
 		.values('day')
 		.annotate(n=Count('id'))
 	)
@@ -109,18 +110,12 @@ def _count_per_day(
 
 
 def _compute_activity(user: Account) -> dict:
-	end = datetime.datetime.now(datetime.timezone.utc).date()
+	end = datetime.datetime.now(datetime.UTC).date()
 	start = end - datetime.timedelta(days=ACTIVITY_WINDOW_DAYS - 1)
-	since = datetime.datetime.combine(
-		start, datetime.time.min, tzinfo=datetime.timezone.utc
-	)
-	until = datetime.datetime.combine(
-		end + datetime.timedelta(days=1),
-		datetime.time.min,
-		tzinfo=datetime.timezone.utc,
-	)
+	since = datetime.datetime.combine(start, datetime.time.min, tzinfo=datetime.UTC)
+	until = since + datetime.timedelta(days=ACTIVITY_WINDOW_DAYS)
 
-	counts: dict[datetime.date, int] = {}
+	counts: Counter[datetime.date] = Counter()
 	# WorkSource uploads are revision-tracked, so counting them separately would
 	# double count them.
 	sources = (
@@ -129,8 +124,7 @@ def _compute_activity(user: Account) -> dict:
 		(XtdComment.objects.filter(user=user, is_removed=False), 'submit_date'),
 	)
 	for qs, field in sources:
-		for day, n in _count_per_day(qs, field, since, until).items():
-			counts[day] = counts.get(day, 0) + n
+		counts.update(_count_per_day(qs, field, since, until))
 
 	# Serialized as ISO strings so the payload survives any cache backend's
 	# serializer; the response schema parses them back into dates.

--- a/backend/otodb/api/profile.py
+++ b/backend/otodb/api/profile.py
@@ -1,11 +1,12 @@
-from datetime import datetime
+import datetime
 from typing import List, Literal
 
+from django.core.cache import cache
 from django.db.models import Count, IntegerField, OuterRef, Q, Subquery
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, TruncDate
 from django.shortcuts import get_object_or_404
 from django_comments_xtd.models import XtdComment
-from ninja import Field, FilterSchema, ModelSchema, Query, Router
+from ninja import Field, FilterSchema, ModelSchema, Query, Router, Schema
 from ninja.errors import HttpError
 from ninja.pagination import paginate
 from ninja.security import django_auth
@@ -68,6 +69,93 @@ def profile(request: AuthedHttpRequest, username: str):
 	return user
 
 
+# Length of the contribution heatmap window, today included.
+ACTIVITY_WINDOW_DAYS = 365
+# The heatmap is expensive to compute and barely changes, so it is cached for an
+# hour. `/api/profile` is excluded from the anonymous response cache (see
+# otodb.middleware), so caching has to happen at the data level; that also keeps
+# it working for logged-in viewers.
+ACTIVITY_CACHE_TIMEOUT = 60 * 60
+
+
+class ActivityDaySchema(Schema):
+	date: datetime.date
+	count: int
+
+
+class ProfileActivitySchema(Schema):
+	start: datetime.date
+	end: datetime.date
+	total: int
+	days: list[ActivityDaySchema]
+
+
+def _count_per_day(
+	qs, field: str, since: datetime.datetime, until: datetime.datetime
+) -> dict[datetime.date, int]:
+	"""Count the rows of `qs` falling in [since, until), bucketed by UTC day.
+
+	TIME_ZONE is left at Django's default, so the bucket boundaries have to be
+	pinned to UTC explicitly to match the window the endpoint reports.
+	"""
+	rows = (
+		qs.filter(**{f'{field}__gte': since, f'{field}__lt': until})
+		.order_by()
+		.annotate(day=TruncDate(field, tzinfo=datetime.timezone.utc))
+		.values('day')
+		.annotate(n=Count('id'))
+	)
+	return {row['day']: row['n'] for row in rows}
+
+
+def _compute_activity(user: Account) -> dict:
+	end = datetime.datetime.now(datetime.timezone.utc).date()
+	start = end - datetime.timedelta(days=ACTIVITY_WINDOW_DAYS - 1)
+	since = datetime.datetime.combine(
+		start, datetime.time.min, tzinfo=datetime.timezone.utc
+	)
+	until = datetime.datetime.combine(
+		end + datetime.timedelta(days=1),
+		datetime.time.min,
+		tzinfo=datetime.timezone.utc,
+	)
+
+	counts: dict[datetime.date, int] = {}
+	# WorkSource uploads are revision-tracked, so counting them separately would
+	# double count them.
+	sources = (
+		(Revision.objects.filter(user=user), 'date'),
+		(ThreadPost.objects.filter(user=user, is_removed=False), 'created_at'),
+		(XtdComment.objects.filter(user=user, is_removed=False), 'submit_date'),
+	)
+	for qs, field in sources:
+		for day, n in _count_per_day(qs, field, since, until).items():
+			counts[day] = counts.get(day, 0) + n
+
+	# Serialized as ISO strings so the payload survives any cache backend's
+	# serializer; the response schema parses them back into dates.
+	return {
+		'start': start.isoformat(),
+		'end': end.isoformat(),
+		'total': sum(counts.values()),
+		'days': [
+			{'date': day.isoformat(), 'count': counts[day]} for day in sorted(counts)
+		],
+	}
+
+
+@profile_router.get('activity', response=ProfileActivitySchema)
+def activity(request: AuthedHttpRequest, username: str):
+	"""Daily contribution counts (revisions, thread posts and comments) over the
+	last year, for the profile heatmap. Days with no activity are omitted."""
+	user = get_object_or_404(Account, username__iexact=username)
+	return cache.get_or_set(
+		f'profile_activity:{user.pk}',
+		lambda: _compute_activity(user),
+		ACTIVITY_CACHE_TIMEOUT,
+	)
+
+
 class ProfileIndexSchema(ModelSchema):
 	id: OtodbID
 	level: Account.Levels
@@ -75,7 +163,7 @@ class ProfileIndexSchema(ModelSchema):
 	revisions_count: int
 	posts_count: int
 	comments_count: int
-	date_created: datetime
+	date_created: datetime.datetime
 
 	class Meta:
 		model = Account

--- a/backend/tests/test_profile_activity.py
+++ b/backend/tests/test_profile_activity.py
@@ -1,0 +1,215 @@
+"""Tests for GET /api/profile/activity (contribution heatmap data)."""
+
+import datetime
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from django_comments_xtd.models import XtdComment
+from ninja.testing import TestClient
+
+from otodb.api.profile import profile_router
+from otodb.models import MediaWork, Revision
+from otodb.models.enums import PostCategory
+from otodb.models.posts import Thread, ThreadPost
+
+
+@pytest.fixture
+def profile_client():
+	"""The endpoint is public, so no authenticated client is needed."""
+	return TestClient(profile_router)
+
+
+def utc_now() -> datetime.datetime:
+	return datetime.datetime.now(datetime.timezone.utc)
+
+
+def days_ago(n: int) -> datetime.datetime:
+	return utc_now() - datetime.timedelta(days=n)
+
+
+def make_revision(user, when: datetime.datetime | None = None) -> Revision:
+	"""Revision.date is auto_now_add, so backdating needs an UPDATE."""
+	rev = Revision.objects.create(user=user, message='test')
+	if when is not None:
+		Revision.objects.filter(pk=rev.pk).update(date=when)
+	return rev
+
+
+def make_thread(user) -> Thread:
+	return Thread.objects.create(
+		title='Test Thread', added_by=user, category=PostCategory.GENERAL
+	)
+
+
+def make_post(
+	thread: Thread,
+	user,
+	num: int,
+	when: datetime.datetime,
+	is_removed: bool = False,
+) -> ThreadPost:
+	return ThreadPost.objects.create(
+		thread=thread,
+		num=num,
+		user=user,
+		body='content',
+		created_at=when,
+		is_removed=is_removed,
+	)
+
+
+def make_comment(user, when: datetime.datetime, is_removed: bool = False) -> XtdComment:
+	# object_pk need not resolve to a real row; only the user/date/flag matter,
+	# and creating a real MediaWork would emit an extra Revision.
+	return XtdComment.objects.create(
+		content_type=ContentType.objects.get_for_model(MediaWork),
+		object_pk='1',
+		site_id=1,
+		user=user,
+		comment='comment',
+		submit_date=when,
+		is_removed=is_removed,
+	)
+
+
+def get_activity(client: TestClient, username: str):
+	return client.get(f'/activity?username={username}')
+
+
+@pytest.mark.django_db
+def test_window_is_365_days_ending_today(profile_client, member):
+	"""start/end span a 365-day window ending today (UTC)."""
+	response = get_activity(profile_client, member.username)
+
+	assert response.status_code == 200
+	body = response.json()
+	end = datetime.date.fromisoformat(body['end'])
+	start = datetime.date.fromisoformat(body['start'])
+	assert end == utc_now().date()
+	assert (end - start).days == 364
+
+
+@pytest.mark.django_db
+def test_counts_aggregate_across_all_three_sources(profile_client, member):
+	"""Revisions, thread posts and comments on the same day are summed."""
+	when = days_ago(3)
+	make_revision(member, when)
+	make_revision(member, when)
+	thread = make_thread(member)
+	make_post(thread, member, 1, when)
+	make_comment(member, when)
+
+	body = get_activity(profile_client, member.username).json()
+
+	assert body['days'] == [{'date': when.date().isoformat(), 'count': 4}]
+	assert body['total'] == 4
+
+
+@pytest.mark.django_db
+def test_removed_posts_and_comments_are_excluded(profile_client, member):
+	"""Soft-removed thread posts and comments do not count."""
+	when = days_ago(2)
+	thread = make_thread(member)
+	make_post(thread, member, 1, when)
+	make_post(thread, member, 2, when, is_removed=True)
+	make_comment(member, when)
+	make_comment(member, when, is_removed=True)
+
+	body = get_activity(profile_client, member.username).json()
+
+	assert body['days'] == [{'date': when.date().isoformat(), 'count': 2}]
+	assert body['total'] == 2
+
+
+@pytest.mark.django_db
+def test_entries_outside_the_window_are_excluded(profile_client, member):
+	"""Anything older than the 365-day window is dropped; the first day is kept."""
+	inside = days_ago(364)
+	make_revision(member, inside)
+	make_revision(member, days_ago(365))
+	make_revision(member, days_ago(400))
+	thread = make_thread(member)
+	make_post(thread, member, 1, days_ago(370))
+	make_comment(member, days_ago(500))
+
+	body = get_activity(profile_client, member.username).json()
+
+	assert body['start'] == inside.date().isoformat()
+	assert body['days'] == [{'date': inside.date().isoformat(), 'count': 1}]
+	assert body['total'] == 1
+
+
+@pytest.mark.django_db
+def test_zero_count_days_are_omitted_and_days_are_sorted(profile_client, member):
+	"""Only days with activity appear, ascending, and total sums them."""
+	make_revision(member, days_ago(1))
+	make_revision(member, days_ago(10))
+	make_revision(member, days_ago(10))
+	make_revision(member, days_ago(30))
+
+	body = get_activity(profile_client, member.username).json()
+
+	assert body['days'] == [
+		{'date': days_ago(30).date().isoformat(), 'count': 1},
+		{'date': days_ago(10).date().isoformat(), 'count': 2},
+		{'date': days_ago(1).date().isoformat(), 'count': 1},
+	]
+	assert body['total'] == 4
+
+
+@pytest.mark.django_db
+def test_other_users_activity_is_not_counted(profile_client, member, editor):
+	"""Only the requested user's own activity is reported."""
+	when = days_ago(5)
+	make_revision(member, when)
+	make_revision(editor, when)
+	make_revision(editor, when)
+
+	body = get_activity(profile_client, member.username).json()
+
+	assert body['total'] == 1
+
+
+@pytest.mark.django_db
+def test_username_lookup_is_case_insensitive(profile_client, member):
+	make_revision(member, days_ago(1))
+
+	response = get_activity(profile_client, member.username.upper())
+
+	assert response.status_code == 200
+	assert response.json()['total'] == 1
+
+
+@pytest.mark.django_db
+def test_unknown_username_returns_404(profile_client):
+	response = get_activity(profile_client, 'nobody')
+
+	assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_response_is_cached_per_user(profile_client, member):
+	"""The payload is cached, so new activity only shows up once it expires."""
+	make_revision(member, days_ago(1))
+
+	first = get_activity(profile_client, member.username).json()
+	assert first['total'] == 1
+
+	make_revision(member, days_ago(1))
+	cached = get_activity(profile_client, member.username).json()
+	assert cached == first
+
+	cache.clear()
+	fresh = get_activity(profile_client, member.username).json()
+	assert fresh['total'] == 2
+
+
+@pytest.mark.django_db
+def test_cache_is_not_shared_between_users(profile_client, member, editor):
+	make_revision(member, days_ago(1))
+	make_revision(editor, days_ago(1))
+	make_revision(editor, days_ago(1))
+
+	assert get_activity(profile_client, member.username).json()['total'] == 1
+	assert get_activity(profile_client, editor.username).json()['total'] == 2

--- a/backend/tests/test_profile_activity.py
+++ b/backend/tests/test_profile_activity.py
@@ -21,7 +21,7 @@ def profile_client():
 
 
 def utc_now() -> datetime.datetime:
-	return datetime.datetime.now(datetime.timezone.utc)
+	return datetime.datetime.now(datetime.UTC)
 
 
 def days_ago(n: int) -> datetime.datetime:


### PR DESCRIPTION
Part 1 of a two-PR stack for #981. This PR adds the API; the heatmap UI that consumes it is stacked on top in #985.

(Supersedes #986, which GitHub marked as merged by accident while the stack was being reordered — nothing from it ever landed on `master`.)

`GET /api/profile/activity?username=…` returns daily contribution counts for the last 365 days (today included), so the profile page has real data to render a GitHub-style heatmap from.

### Counting

A day's count is the number of revisions, thread posts and comments the user made on that UTC day — the same three sources `profile/search` already reports as `revisions_count` / `posts_count` / `comments_count`. Removed posts and comments are excluded. Days with no activity are omitted, and the response carries the window bounds plus the total:

```json
{
  "start": "2025-08-08",
  "end": "2026-08-07",
  "total": 1234,
  "days": [{ "date": "2025-08-10", "count": 3 }]
}
```

The five-level bucketing a heatmap needs is deliberately left to the client, so the response stays minimal and cache-friendly.

`WorkSource` uploads are deliberately not counted separately: `WorkSource` is revision tracked, so an upload already shows up as a revision and counting both would double count it.

Day buckets are pinned to UTC explicitly with `TruncDate(…, tzinfo=timezone.utc)`. `TIME_ZONE` is not configured, so Django's default would otherwise shift the boundaries away from the window the endpoint reports.

### Caching

The result is cached for an hour under `profile_activity:<user id>` via `cache.get_or_set`. `/api/profile` is excluded from `AnonymousReadOnlyCacheMiddleware`, so the caching has to happen at the data level; that also makes it apply to logged-in viewers. This needs no new dependency or infrastructure — it uses LocMemCache in development and the existing Valkey cache in production.

The tradeoff is that a user's own new edit can take up to an hour to appear in their heatmap. Lowering `ACTIVITY_CACHE_TIMEOUT` is a one-line change if that turns out to be too coarse.

The payload is cached with the dates as ISO strings rather than `date` objects, so it survives any cache backend's serializer; the response schema parses them back. The wire format is unchanged.

### Tests

`tests/test_profile_activity.py` covers the 365-day window bounds, aggregation across all three sources on one day, exclusion of removed posts and comments, exclusion of out-of-window entries, omission of zero-count days with a correct total, other users' activity not leaking in, case-insensitive username lookup, 404 for an unknown username, and the caching behaviour (both that it caches and that it is not shared between users).
