### PR TITLE
Add `noindex` to every page that shows a list

### DIFF
--- a/frontend/src/routes/(auth)/login/+page.svelte
+++ b/frontend/src/routes/(auth)/login/+page.svelte
@@ -14,6 +14,10 @@
 	});
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={m.inner_stale_anteater_walk()}>
 	<form method="POST" use:dirtyEnhance>
 		<table>

--- a/frontend/src/routes/(auth)/register/+page.svelte
+++ b/frontend/src/routes/(auth)/register/+page.svelte
@@ -17,6 +17,10 @@
 	});
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={m.blue_whole_camel_type()}>
 	<form method="POST" use:dirtyEnhance>
 		<table>

--- a/frontend/src/routes/(auth)/reset_password/+page.svelte
+++ b/frontend/src/routes/(auth)/reset_password/+page.svelte
@@ -17,6 +17,10 @@
 	});
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={m.true_tough_butterfly_sew()}>
 	{#if form?.reset_success}
 		<p>{m.stock_jolly_crocodile_cheer()}</p>

--- a/frontend/src/routes/comments/+page.svelte
+++ b/frontend/src/routes/comments/+page.svelte
@@ -9,6 +9,10 @@
 	let { data } = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={m.same_broad_haddock_pinch()}>
 	<table class="w-full table-fixed">
 		<colgroup>

--- a/frontend/src/routes/list/+page.svelte
+++ b/frontend/src/routes/list/+page.svelte
@@ -8,6 +8,10 @@
 	let { data } = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section
 	title={m.stale_loose_squid_cut()}
 	type={m.mean_top_antelope_love()}

--- a/frontend/src/routes/list/[list_id]/+page.svelte
+++ b/frontend/src/routes/list/[list_id]/+page.svelte
@@ -37,6 +37,10 @@
 	});
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={data.list.name} type={m.stale_loose_squid_cut()} menuLinks={data.links}>
 	<h3>
 		{#if isSVO(getLocale())}

--- a/frontend/src/routes/moderation/+page.svelte
+++ b/frontend/src/routes/moderation/+page.svelte
@@ -39,6 +39,10 @@
 	};
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <div class="mb-4 flex gap-2">
 	{#each tabs as tab (tab.key)}
 		<a

--- a/frontend/src/routes/moderation/history/+page.svelte
+++ b/frontend/src/routes/moderation/history/+page.svelte
@@ -6,6 +6,10 @@
 	let { data } = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <ModerationEventsTable events={data.events} />
 
 {#if data.events?.count}

--- a/frontend/src/routes/notifications/+page.svelte
+++ b/frontend/src/routes/notifications/+page.svelte
@@ -32,6 +32,10 @@
 	};
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <div
 	class="grid grid-cols-[repeat(auto-fill,minmax(max(calc(50%-var(--spacing)*2),min(100%,576px)),1fr))] gap-x-4"
 >

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -33,6 +33,10 @@
 	}
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 {#snippet sortHeader(col: SortableColumn, label: string)}
 	<a href={sortUrl(col)} class="inline-flex items-center justify-end whitespace-nowrap">
 		<span>{label}</span>

--- a/frontend/src/routes/profile/[username]/revisions/+page.svelte
+++ b/frontend/src/routes/profile/[username]/revisions/+page.svelte
@@ -31,6 +31,10 @@
 	};
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={data.profile.username} type={m.fuzzy_crazy_cobra_lead()} menuLinks={data.links}>
 	{#if is_mod}
 		<div class="my-4 flex items-center gap-2">

--- a/frontend/src/routes/profile/[username]/submissions/+page.svelte
+++ b/frontend/src/routes/profile/[username]/submissions/+page.svelte
@@ -28,6 +28,10 @@
 	);
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={data.profile.username} type={m.fuzzy_crazy_cobra_lead()} menuLinks={data.links}>
 	{#if data.user?.username === data.profile.username}
 		<a href="/upload/add">{m.fluffy_crisp_horse_imagine()}</a>

--- a/frontend/src/routes/profile/[username]/threads/+page.svelte
+++ b/frontend/src/routes/profile/[username]/threads/+page.svelte
@@ -9,6 +9,10 @@
 	let { data }: PageProps = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={data.profile.username} type={m.fuzzy_crazy_cobra_lead()} menuLinks={data.links}>
 	<a href="/thread/new?category=3&entity=@{data.profile.username}">{m.antsy_aloof_horse_grace()}</a>
 	{#if data.threads.items.length}

--- a/frontend/src/routes/revision/+page.svelte
+++ b/frontend/src/routes/revision/+page.svelte
@@ -27,6 +27,10 @@
 	let filtersOpen = $state(Object.values(data.filters).some((v) => v !== undefined));
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={m.giant_away_scallop_hike()}>
 	<form target="_self" method="get">
 		<details bind:open={filtersOpen}>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -41,6 +41,10 @@
 	}
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={m.orange_born_seal_ascend()}>
 	<div class="flex flex-col gap-8">
 		<div>

--- a/frontend/src/routes/song/+page.svelte
+++ b/frontend/src/routes/song/+page.svelte
@@ -9,6 +9,10 @@
 	let { data } = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section
 	title={m.grand_nice_pony_belong()}
 	type={m.mean_top_antelope_love()}

--- a/frontend/src/routes/song_attribute/+page.svelte
+++ b/frontend/src/routes/song_attribute/+page.svelte
@@ -26,6 +26,10 @@
 		});
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section
 	title={m.dull_plain_angelfish_cuddle()}
 	type={m.mean_top_antelope_love()}

--- a/frontend/src/routes/song_attribute/[tag_slug]/+page.svelte
+++ b/frontend/src/routes/song_attribute/[tag_slug]/+page.svelte
@@ -17,6 +17,10 @@
 	);
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={data.display_name} type={m.dull_plain_angelfish_cuddle()} menuLinks={data.links}>
 	<div>
 		<span>{m.dull_plain_angelfish_cuddle()}</span>

--- a/frontend/src/routes/tag/+page.svelte
+++ b/frontend/src/routes/tag/+page.svelte
@@ -17,6 +17,10 @@
 	let category = $state(data.category);
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section
 	title={m.empty_legal_chicken_taste()}
 	type={m.mean_top_antelope_love()}

--- a/frontend/src/routes/tag/[tag_slug]/threads/+page.svelte
+++ b/frontend/src/routes/tag/[tag_slug]/threads/+page.svelte
@@ -7,6 +7,10 @@
 	let { data } = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={data.tag.name} type={m.big_tiny_kitten_devour()} menuLinks={data.links}>
 	<a href="/thread/new?category=3&entity=[[{data.tag.slug}]]">{m.antsy_aloof_horse_grace()}</a>
 	{#if data.threads.items.length}

--- a/frontend/src/routes/thread/+page.svelte
+++ b/frontend/src/routes/thread/+page.svelte
@@ -12,6 +12,10 @@
 	let { data } = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section
 	title={m.just_salty_anaconda_nourish()}
 	type={m.mean_top_antelope_love()}

--- a/frontend/src/routes/thread/[id]/+page.svelte
+++ b/frontend/src/routes/thread/[id]/+page.svelte
@@ -76,6 +76,7 @@
 </script>
 
 <svelte:head>
+	<meta name="robots" content="noindex" />
 	{#if postLd}
 		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		{@html postLd}

--- a/frontend/src/routes/upload/+page.svelte
+++ b/frontend/src/routes/upload/+page.svelte
@@ -9,6 +9,10 @@
 	let { data } = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title="Sources">
 	<form method="get" class="mb-4 flex flex-wrap items-end gap-3">
 		<label class="flex flex-col gap-1">

--- a/frontend/src/routes/wiki/+page.svelte
+++ b/frontend/src/routes/wiki/+page.svelte
@@ -25,6 +25,10 @@
 	}
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={data.head.title}>
 	<form method="get" class="mb-4 flex flex-wrap items-end gap-1">
 		<label class="flex flex-col text-sm">

--- a/frontend/src/routes/work/+page.svelte
+++ b/frontend/src/routes/work/+page.svelte
@@ -20,6 +20,10 @@
 	];
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section
 	title={m.grand_merry_fly_succeed()}
 	type={m.mean_top_antelope_love()}

--- a/frontend/src/routes/work/[work_id]/threads/+page.svelte
+++ b/frontend/src/routes/work/[work_id]/threads/+page.svelte
@@ -7,6 +7,10 @@
 	let { data } = $props();
 </script>
 
+<svelte:head>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
 <Section title={data.title} type={m.grand_merry_fly_succeed()} menuLinks={data.links}>
 	<a href="/thread/new?category=3&entity=w{data.id}">{m.antsy_aloof_horse_grace()}</a>
 	{#if data.threads.items.length}


### PR DESCRIPTION
#889 のレビューから切り出したPR。`noindex` タグの追加だけを含む。canonical URL、description、OGP画像、`<title>` の文言には触れない。

## 方針

検索エンジンにインデックスさせる価値があるのは、1件の作品・タグ・プロフィールを表示するページだけ。一覧を表示するページは、リンク先のページの内容を繰り返す。さらに2ページ目以降は1ページ目の内容を繰り返す。

そこで `Pager` を表示する全ルートと、アカウント系の4ページに、それぞれの `<svelte:head>` で `<meta name="robots" content="noindex">` を宣言する。値はルートごとの定数なので、`load()` から渡す必要はない。

`noindex` はクロールそのものを止めない。クローラは今まで通りこれらのページのリンクを辿るので、一覧ページは発見経路として機能し続ける。

## 対象の26ページ

- 一覧: `/comments`, `/list`, `/profile`, `/revision`, `/song`, `/song_attribute`, `/tag`, `/thread`, `/wiki`, `/work`
- 自身の内容を複数ページに分けて表示するページ: `/list/[list_id]`, `/song_attribute/[tag_slug]`, `/thread/[id]`, `/tag/[tag_slug]/threads`, `/work/[work_id]/threads`, `/profile/[username]/revisions`, `/profile/[username]/submissions`, `/profile/[username]/threads`
- ログイン中のユーザー向けのページ: `/moderation`, `/moderation/history`, `/notifications`, `/upload`
- アカウント関連のページ: `/login`, `/register`, `/reset_password`, `/settings`

## robots.txt には触らない

`static/robots.txt` はこのPRでは変更しない。サイトマップの送信内容と `noindex` の整合性は別のPRで扱う。
