### PR TITLE
Pin down the layout of the submission table on `/profile/[username]/submissions`

### DIFF
--- a/frontend/src/routes/profile/[username]/submissions/+page.svelte
+++ b/frontend/src/routes/profile/[username]/submissions/+page.svelte
@@ -98,49 +98,66 @@
 	<hr class="my-2" />
 	<h2>{SubmissionStandingNames[standing]()}</h2>
 	{#if data.submissions?.items.length}
-		<table class="w-full">
-			<thead
-				><tr>
-					<th>{m.large_factual_octopus_exhale()}</th>
-					<th>{m.sour_swift_sparrow_spin()}</th>
-					<th>{m.super_agent_pigeon_aim()}</th>
-					<th>{m.large_polite_otter_thrive()}</th>
+		<div class="overflow-x-auto">
+			<table class="w-full min-w-2xl table-fixed wrap-anywhere">
+				<colgroup>
+					<col />
+					<col class="w-1/12" />
+					<col class="w-2/12" />
+					<col class="w-1/12" />
 					{#if isBound}
-						<th>{m.civil_trick_oryx_clap()}</th>
+						<col class="w-1/12" />
 					{/if}
-					<th>{m.noisy_moving_newt_belong()}</th>
+					<col class="w-1/12" />
 					{#if canRefresh}
-						<th>{m.mushy_proof_hornet_dig()}</th>
+						<col class="w-2/12" />
 					{/if}
-				</tr></thead
-			>
-			<tbody>
-				{#each data.submissions.items as src, i (i)}
-					<tr>
-						<td class="whitespace-nowrap">
-							{#if isBound}
-								<a href="/work/{src.media}">#{src.media} - {src.title || src.url}</a>
-							{:else}
-								<a href="/upload/{src.id}">{src.title || src.url}</a>
-							{/if}
-						</td>
-						<td>{PlatformNames[src.platform]}</td><td>{src.published_date}</td>
-						<td class="whitespace-nowrap">{WorkOriginNames[src.work_origin]()}</td>
+				</colgroup>
+				<thead
+					><tr>
+						<th>{m.large_factual_octopus_exhale()}</th>
+						<th>{m.sour_swift_sparrow_spin()}</th>
+						<th>{m.super_agent_pigeon_aim()}</th>
+						<th>{m.large_polite_otter_thrive()}</th>
 						{#if isBound}
-							<td class="whitespace-nowrap">{WorkStatusNames[src.work_status]()}</td>
+							<th>{m.civil_trick_oryx_clap()}</th>
 						{/if}
-						<td class="whitespace-nowrap"
-							><a href={src.url} target="_blank" rel="noopener noreferrer"
-								>{m.noisy_moving_newt_belong()}</a
-							></td
-						>
+						<th>{m.noisy_moving_newt_belong()}</th>
 						{#if canRefresh}
-							<td><RefreshButton source={src} /></td>
+							<th>{m.mushy_proof_hornet_dig()}</th>
 						{/if}
-					</tr>
-				{/each}
-			</tbody>
-		</table>
+					</tr></thead
+				>
+				<tbody>
+					{#each data.submissions.items as src, i (i)}
+						<tr>
+							<td>
+								{#if isBound}
+									<a href="/work/{src.media}">#{src.media} - {src.title || src.url}</a>
+								{:else}
+									<a href="/upload/{src.id}">{src.title || src.url}</a>
+								{/if}
+							</td>
+							<td>{PlatformNames[src.platform]}</td><td class="whitespace-nowrap"
+								>{src.published_date}</td
+							>
+							<td>{WorkOriginNames[src.work_origin]()}</td>
+							{#if isBound}
+								<td>{WorkStatusNames[src.work_status]()}</td>
+							{/if}
+							<td
+								><a href={src.url} target="_blank" rel="noopener noreferrer"
+									>{m.noisy_moving_newt_belong()}</a
+								></td
+							>
+							{#if canRefresh}
+								<td><RefreshButton source={src} /></td>
+							{/if}
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
 	{:else}
 		<p>{m.moving_such_seal_hug()}</p>
 	{/if}

--- a/frontend/src/routes/profile/[username]/submissions/page.stories.ts
+++ b/frontend/src/routes/profile/[username]/submissions/page.stories.ts
@@ -104,7 +104,10 @@ const pendingSubmissions = {
 			platform: Platform.Niconico,
 			work_origin: WorkOrigin.Reupload,
 			work_status: WorkStatus.Available,
-			url: 'https://www.nicovideo.jp/watch/example2',
+			// No title yet, so the Title column falls back to this URL. A query
+			// string makes it the widest string with no break opportunity that the
+			// column has to fit.
+			url: 'https://www.nicovideo.jp/watch/example2?ref=search_key_video&playlist=eyJpZCI6IiUyRnNlYXJjaCUyRmV4YW1wbGUiLCJ0eXBlIjoic2VhcmNoIn0',
 			published_date: '2024-02-15',
 			work_width: null,
 			work_height: null,


### PR DESCRIPTION
## Problem

The submission table uses the default auto table layout with no width limits. Each column gets its width from the content that comes on that page. This is the same defect as `/comments` (#984) and `/upload` (#996).

The Title cell shows `src.title || src.url`, so a source that has no metadata yet shows the raw submitted URL. A URL has no break opportunity.

The cell also carried `whitespace-nowrap`. That class looked like it prevented overflow, but it stopped the URL from breaking at all, so it guaranteed the overflow instead.

The list is paginated, so the column widths also move from one page to the next. `main` is a `grow` flex item, so a wide table pulls the whole content column wider.

## Fix

The table now uses `w-full table-fixed` with a `colgroup`, the idiom that `ThreadTable.svelte` and `/comments` already use.

- Column widths are twelfths, not fixed rem. A percentage follows the container, so the table can never become wider than the container.
- `wrap-anywhere` on the table lets the URL break instead of pushing its column out.
- `whitespace-nowrap` stays only on the published date, whose shape is fixed.
- The table holds up to seven columns, which cannot stay readable in a phone-width box. An `overflow-x-auto` wrapper with `min-w-2xl` keeps the column widths and moves the sideways scroll into the table itself.

## Story

The story fixture for the pending submission now holds a URL with a query string, so the content shape that broke the layout is visible in Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)