### PR TITLE
Pin down the layout of the revision table in `HistoryView`

### DIFF
--- a/frontend/src/lib/HistoryView.svelte
+++ b/frontend/src/lib/HistoryView.svelte
@@ -15,26 +15,37 @@
 	let { revisions, batch_size, page_param }: Props = $props();
 </script>
 
-<table class="w-full table-auto text-center">
-	<tbody>
-		<tr>
-			<th>Version</th><th>Revision</th><th>Action</th><th>{m.fuzzy_crazy_cobra_lead()}</th><th
-				>{m.super_agent_pigeon_aim()}</th
-			><th>{m.weary_spicy_fly_attend()}</th>
-		</tr>
-		{#each revisions.items as rev, i (i)}
-			<tr
-				><td>{rev.index}</td><td><a href="/revision/{rev.id}">#{rev.id}</a></td><td
-					>{rev.route !== null && rev.route !== undefined ? routeNames[rev.route]() : ''}</td
-				><td>
-					<a href="/profile/{rev.user}">{rev.user}</a>
-				</td><td>
-					<Time format="relative" date={rev.date} />
-				</td><td>
-					{rev.message}
-				</td>
+<div class="overflow-x-auto">
+	<table class="w-full min-w-3xl table-fixed text-center wrap-anywhere">
+		<colgroup>
+			<col class="w-1/12" />
+			<col class="w-1/12" />
+			<col class="w-2/12" />
+			<col class="w-2/12" />
+			<col class="w-2/12" />
+			<col />
+		</colgroup>
+		<tbody>
+			<tr>
+				<th>Version</th><th>Revision</th><th>Action</th><th>{m.fuzzy_crazy_cobra_lead()}</th><th
+					>{m.super_agent_pigeon_aim()}</th
+				><th>{m.weary_spicy_fly_attend()}</th>
 			</tr>
-		{/each}
-	</tbody>
-</table>
+			{#each revisions.items as rev, i (i)}
+				<tr
+					><td class="whitespace-nowrap">{rev.index}</td><td class="whitespace-nowrap"
+						><a href="/revision/{rev.id}">#{rev.id}</a></td
+					><td>{rev.route !== null && rev.route !== undefined ? routeNames[rev.route]() : ''}</td
+					><td>
+						<a href="/profile/{rev.user}">{rev.user}</a>
+					</td><td>
+						<Time format="relative" date={rev.date} />
+					</td><td>
+						{rev.message}
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>
 <Pager page_size={batch_size} n_count={revisions.count} param_name={page_param} />

--- a/frontend/src/routes/work/[work_id]/history/page.stories.ts
+++ b/frontend/src/routes/work/[work_id]/history/page.stories.ts
@@ -122,7 +122,10 @@ const revisions = [
 		user: 'mod_user',
 		index: 2,
 		route: Route.Rollback,
-		message: 'Rolled back a vandalism edit.'
+		// An edit message is free text, so it can hold a pasted URL. A URL has no
+		// break opportunity, which is the shape that used to widen the column.
+		message:
+			'Rolled back a vandalism edit. Source: https://www.nicovideo.jp/watch/sm0000002?ref=search_key_video&playlist=eyJpZCI6IiUyRnNlYXJjaCUyRmV4YW1wbGUiLCJ0eXBlIjoic2VhcmNoIn0'
 	},
 	{
 		id: '100',


### PR DESCRIPTION
## Problem

`HistoryView.svelte` asks for the auto table layout (`table-auto`), so each of its six columns gets its width from the content that comes on that page. This is the same defect as `/comments` (#984).

The list is paginated, so the column widths move from one page to the next. `main` is a `grow` flex item, so a wide table pulls the whole content column wider.

The last column shows the edit message, which is free text and can hold a pasted URL. A URL has no break opportunity, so it widens the column and spills past the section border.

## Fix

The table now uses `w-full table-fixed` with a `colgroup`, the idiom that `ThreadTable.svelte` and `/comments` already use.

- Column widths are twelfths, not fixed rem. A percentage follows the container, so the table can never become wider than the container.
- `wrap-anywhere` on the table lets the message break instead of pushing its column out.
- The version index and the revision id keep `whitespace-nowrap`, because their shape is fixed.
- Six columns cannot stay readable in a phone-width box, so an `overflow-x-auto` wrapper with `min-w-3xl` keeps the column widths and moves the sideways scroll into the table itself.

## Scope

`HistoryView` serves four pages: the history of a work, a wiki page, a tag and a song attribute. One change fixes all four.

## Story

Only the history of a work has a story today, so the story fixture there now holds an edit message with a URL in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)