### PR TITLE
Pin down the layout of both preview tables on the front page

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -46,39 +46,52 @@
 	</Section>
 
 	<Section title={m.sea_cute_beaver_file()} href="/revision">
-		<table class="w-full">
-			<tbody>
-				{#each data.changes.items as r, i (i)}
-					<tr
-						><td><a href="/revision/{r.id}">#{r.id}</a> </td><td
-							>{typeof r.route === 'number' ? routeNames[r.route]() : ''}</td
-						><td
-							>{#if r.first_entity}<a
-									href={buildEntityRoutes(r.first_entity.entity, r.first_entity.id)}
-									>{r.first_entity.id}</a
-								>{#if r.n_ent > 1}{m.mellow_brave_marten_gather({
-										count: r.n_ent - 1
-									})}{/if}{/if}</td
-						><td
-							><Time format="relative" date={r.date} />
-							<ParaglideMessage message={m.noble_tidy_boar_lock} inputs={{}}
-								>{#snippet content()}<a href="/profile/{r.user}">{r.user}</a
-									>{/snippet}</ParaglideMessage
-							></td
-						></tr
-					>
-				{/each}
-			</tbody>
-		</table>
+		<div class="overflow-x-auto">
+			<table class="w-full min-w-xl table-fixed wrap-anywhere">
+				<colgroup>
+					<col class="w-2/12" />
+					<col class="w-3/12" />
+					<col class="w-3/12" />
+					<col />
+				</colgroup>
+				<tbody>
+					{#each data.changes.items as r, i (i)}
+						<tr
+							><td class="whitespace-nowrap"><a href="/revision/{r.id}">#{r.id}</a> </td><td
+								>{typeof r.route === 'number' ? routeNames[r.route]() : ''}</td
+							><td
+								>{#if r.first_entity}<a
+										href={buildEntityRoutes(r.first_entity.entity, r.first_entity.id)}
+										>{r.first_entity.id}</a
+									>{#if r.n_ent > 1}{m.mellow_brave_marten_gather({
+											count: r.n_ent - 1
+										})}{/if}{/if}</td
+							><td
+								><Time format="relative" date={r.date} />
+								<ParaglideMessage message={m.noble_tidy_boar_lock} inputs={{}}
+									>{#snippet content()}<a href="/profile/{r.user}">{r.user}</a
+										>{/snippet}</ParaglideMessage
+								></td
+							></tr
+						>
+					{/each}
+				</tbody>
+			</table>
+		</div>
 		<a href="/revision" class="float-right">{m.fresh_deft_warbler_edit()}</a>
 	</Section>
 
 	<Section title={m.curly_fuzzy_turkey_launch()} href="/thread/overview">
-		<table class="w-full">
+		<table class="w-full table-fixed wrap-anywhere">
+			<colgroup>
+				<col class="w-6" />
+				<col />
+				<col class="w-5/12" />
+			</colgroup>
 			<tbody>
 				{#each data.posts.items as p, i (i)}
 					<tr>
-						<td class="w-6 text-center">
+						<td class="text-center">
 							{#if p.closed_at}
 								<Icon key="thread-closed" class="mx-auto block size-4" />
 							{:else}


### PR DESCRIPTION
## Problem

The recent-changes table and the recent-threads table on `/` use the default auto table layout with no width limits. Each column gets its width from the content that comes on that page. This is the same defect as `/comments` (#984).

Neither table is paginated, so the columns do not move between pages. They do move whenever the previews refresh, and the thread title is free text that can hold a pasted URL with no break opportunity.

Both tables sit in a two-column grid, so each has about half the page to work with. A wide table pushes past its section border.

## Fix

Both tables now use `w-full table-fixed` with a `colgroup`, the idiom that `ThreadTable.svelte` and `/comments` already use.

- Column widths are twelfths, so they follow the container.
- `wrap-anywhere` on the table lets a title or a route break instead of pushing its column out.
- The revision id keeps `whitespace-nowrap`, because its shape is fixed.
- A relative time and an author name cannot squeeze into half of a phone-width page, so an `overflow-x-auto` wrapper with `min-w-xl` keeps the column widths and moves the sideways scroll into the table itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)