### PR TITLE
Pin down the layout of the revision table on `/profile/[username]/revisions`

### DIFF
--- a/frontend/src/routes/profile/[username]/revisions/+page.svelte
+++ b/frontend/src/routes/profile/[username]/revisions/+page.svelte
@@ -43,28 +43,38 @@
 		</div>
 	{/if}
 	{#if data.revisions?.items.length}
-		<table class="w-full">
-			<tbody>
-				{#each data.revisions?.items as r, i (i)}
-					<tr>
-						<td>
-							<a href="/revision/{r.id}">#{r.id}</a>
-						</td>
-						<td>{r.route ? routeNames[r.route]() : ''}</td>
-						<td>
-							<Time format="relative" date={r.date} />
-						</td>
-						{#if is_mod}
-							<td>
-								<button {@attach dirtyClick(() => rollbackSince(r.date, `#${r.id}`))}>
-									{m.bold_keen_otter_vault()}
-								</button>
+		<div class="overflow-x-auto">
+			<table class="w-full min-w-xl table-fixed wrap-anywhere">
+				<colgroup>
+					<col class="w-2/12" />
+					<col />
+					<col class="w-3/12" />
+					{#if is_mod}
+						<col class="w-3/12" />
+					{/if}
+				</colgroup>
+				<tbody>
+					{#each data.revisions?.items as r, i (i)}
+						<tr>
+							<td class="whitespace-nowrap">
+								<a href="/revision/{r.id}">#{r.id}</a>
 							</td>
-						{/if}
-					</tr>
-				{/each}
-			</tbody>
-		</table>
+							<td>{r.route ? routeNames[r.route]() : ''}</td>
+							<td>
+								<Time format="relative" date={r.date} />
+							</td>
+							{#if is_mod}
+								<td>
+									<button {@attach dirtyClick(() => rollbackSince(r.date, `#${r.id}`))}>
+										{m.bold_keen_otter_vault()}
+									</button>
+								</td>
+							{/if}
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
 	{:else}
 		<p>{m.spry_dizzy_mouse_roam()}</p>
 	{/if}


### PR DESCRIPTION
## Problem

The table uses the default auto table layout with no width limits. Each column gets its width from the content that comes on that page. This is the same defect as `/comments` (#984).

The list is paginated, so the column widths move from one page to the next. `main` is a `grow` flex item, so a wide table pulls the whole content column wider.

No column holds a URL here, so this table does not overflow as badly as the ones on `/upload` or `/comments`. The action name and the relative time still change length from page to page, and a moderator sees a fourth column with a button in it, which cannot wrap at all.

## Fix

The table now uses `w-full table-fixed` with a `colgroup`, the idiom that `ThreadTable.svelte` and `/comments` already use.

- Column widths are twelfths, so they follow the container.
- The revision id keeps `whitespace-nowrap`, because its shape is fixed.
- An `overflow-x-auto` wrapper with `min-w-xl` keeps the columns readable on a phone and moves the sideways scroll into the table itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)