### PR TITLE
Let a long tag name wrap on `/tag`

### DIFF
--- a/frontend/src/routes/tag/+page.svelte
+++ b/frontend/src/routes/tag/+page.svelte
@@ -134,7 +134,7 @@
 
 	<hr class="my-5" />
 
-	<table class="w-full">
+	<table class="w-full table-fixed wrap-anywhere">
 		<tbody>
 			{#each data.results?.items ?? [] as tag, i (i)}
 				<tr class="border-otodb-bg-fainter border-b">

--- a/frontend/src/routes/tag/page.stories.ts
+++ b/frontend/src/routes/tag/page.stories.ts
@@ -36,6 +36,18 @@ const results: TagWorkSearchResult[] = [
 		category: WorkTagCategory.Source,
 		deprecated: true,
 		n_instance: 3
+	},
+	{
+		// A single unbroken run of characters, so the row only stays inside the
+		// table if the cell is allowed to wrap mid-word.
+		id: '4',
+		lang_prefs: [],
+		aliased_to: null,
+		name: 'Exampleunbreakabletagnamewithnowhitespaceatallanywhereinsideit',
+		slug: 'example-unbreakable-tag-name',
+		category: WorkTagCategory.Creator,
+		deprecated: false,
+		n_instance: 8
 	}
 ];
 


### PR DESCRIPTION
## Problem

The tag list has one column, so it does not have the column-shift half of the `/comments` defect (#984). It has the other half.

A tag name is a single run of characters and can hold no whitespace at all, so it had no break opportunity and pushed the table past its section border.

## Fix

The table now uses `table-fixed` with `wrap-anywhere`, so the cell can never become wider than the container and a long name breaks mid-word instead of spilling out.

A `colgroup` earns nothing here, because there is only one column.

## Story

The story fixture now holds a tag whose name has no whitespace, so the content shape that broke the layout is visible in Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)