### PR TITLE
Add a page-level Storybook story for `/list`

### DIFF
--- a/frontend/src/routes/list/page.stories.ts
+++ b/frontend/src/routes/list/page.stories.ts
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import type { ComponentProps } from 'svelte';
+import { m } from '$lib/paraglide/messages.js';
+import { Levels, type components } from '$lib/schema';
+import Page from './+page.svelte';
+
+type List = components['schemas']['ListSchema'];
+
+const stats = { works: 1234, tags: 567, songs: 89, lists: 54 };
+
+const head = {
+	title: m.mild_loud_shad_enchant({
+		type: m.mean_top_antelope_love(),
+		name: m.stale_loose_squid_cut()
+	})
+};
+
+const memberUser = {
+	csrf: 'csrf-token',
+	user_id: '1',
+	username: 'member_user',
+	level: Levels.Member,
+	prefs: {
+		THEME: 0,
+		VIDEO_PLATFORM: 0,
+		PREFER_AUTHOR_UPLOAD: false
+	},
+	notifs_count: 0,
+	notifs_nonsub_count: 0
+};
+
+const batch_size = 20;
+
+// Production holds this many lists, 20 to a page, so the page always shows a
+// full batch and a pager.
+const total_count = 54;
+
+const author = (id: string, username: string) => ({
+	id,
+	username,
+	level: Levels.Member,
+	date_created: '2023-01-15T09:00:00Z'
+});
+
+// `name` is arbitrary user text. The templates cover the shapes that the column
+// must hold: short names, long names with spaces, non-Latin names, and one name
+// that is a single run of characters with no break opportunity. The last one is
+// what pushes the table past the section, so the layout fix needs to see it.
+const templates = [
+	{
+		author: author('1', 'member_user'),
+		upstream: null,
+		name: 'Favourite uploads of 2024',
+		description: 'A short list of the uploads that I replay the most.'
+	},
+	{
+		author: author('2', 'editor_user'),
+		upstream: null,
+		name: 'お気に入りの音MAD',
+		description: null
+	},
+	{
+		author: author('3', 'archivist_user'),
+		upstream: 'https://example.com/playlists/1',
+		name: 'A considerably longer list name that wraps onto several lines, so the column can be checked against realistic text rather than a single short phrase',
+		description: 'Imported from an external playlist.'
+	},
+	{
+		author: author('4', 'a_notably_long_account_name_user'),
+		upstream: null,
+		name: 'ThisListNameIsOneVeryLongRunOfCharactersWithNoWhitespaceOrHyphenAnywhereInItSoTheBrowserFindsNoBreakOpportunityAtAll',
+		description: null
+	},
+	{
+		author: author('5', 'mod_user'),
+		upstream: null,
+		name: 'Reference tracks',
+		description: null
+	}
+] satisfies Omit<List, 'id'>[];
+
+const lists: List[] = Array.from({ length: batch_size }, (_, i) => ({
+	...templates[i % templates.length],
+	id: String(i + 1)
+}));
+
+const baseData = {
+	user: memberUser,
+	stats,
+	head,
+	query: '',
+	results: { items: lists, count: total_count },
+	batch_size
+};
+
+const meta = {
+	component: Page,
+	args: {
+		data: baseData
+	}
+} satisfies Meta<ComponentProps<typeof Page>>;
+
+export default meta;
+type Story = StoryObj<ComponentProps<typeof Page>>;
+
+/** A full batch of `batch_size` lists with the pager below the table. */
+export const Default: Story = {};
+
+/** A query that matches only part of the collection. */
+export const WithQuery: Story = {
+	args: {
+		data: {
+			...baseData,
+			query: 'reference',
+			results: { items: [{ ...templates[4], id: '5' }], count: 1 }
+		}
+	}
+};
+
+/**
+ * The collection itself is never empty, but a query that matches nothing is
+ * reachable, and that is the only way to see this state.
+ */
+export const QueryWithNoResults: Story = {
+	args: {
+		data: {
+			...baseData,
+			query: 'a query that matches nothing',
+			results: { items: [], count: 0 }
+		}
+	}
+};


### PR DESCRIPTION
## What this adds

A page-level Storybook story for `/list` at `frontend/src/routes/list/page.stories.ts`. It changes no production code.

Stories:

- `Default` — a full batch of 20 lists with a total count of 54, so the pager renders. This matches the scale of the real page.
- `WithQuery` — a query that matches one list.
- `QueryWithNoResults` — a query that matches nothing. The collection itself is never empty, so this state is only reachable through a query.

## Why it is needed

The table on `/list` uses the auto table layout. The `name` field is arbitrary user text, so it can hold a long run of characters with no break opportunity. That content pushes the table past its section. Issue #984 reports the same defect on `/comments`.

A person cannot check the layout without a story, because the page needs the backend. The fixture therefore holds one list name that is a single unbroken run of characters. A later PR can fix the layout and use this story to verify the fix.

## Fixture rules

- All list names and usernames are invented. The fixture holds no real data.
- The fixture uses fixed values only. It calls no clock function and no random function, so each render gives the same result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)