### PR TITLE
Add a page-level Storybook story for `/song`

### DIFF
--- a/frontend/src/routes/song/page.stories.ts
+++ b/frontend/src/routes/song/page.stories.ts
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import type { ComponentProps } from 'svelte';
+import { m } from '$lib/paraglide/messages.js';
+import type { components } from '$lib/schema';
+import Page from './+page.svelte';
+
+type Song = components['schemas']['SongSchema'];
+
+const stats = { works: 1234, tags: 567, songs: 89, lists: 42 };
+
+const batch_size = 20;
+
+// Production serves roughly this many songs, 20 to a page, so the list is
+// never short enough to render without a pager.
+const total_count = 6998;
+
+/** Every title and author here is invented. No real song data goes in a story. */
+const templates: Omit<Song, 'id'>[] = [
+	{
+		work_tag: 'example-media-alpha',
+		tags: [],
+		title: 'Marmalade Skyline',
+		author: 'Fictitious Ensemble',
+		bpm: 128,
+		variable_bpm: false
+	},
+	{
+		work_tag: 'example-media-beta',
+		tags: [],
+		title: 'ぐるぐるパラダイス（架空バージョン）',
+		author: '架空P',
+		bpm: 174,
+		variable_bpm: false
+	},
+	{
+		// The tempo changes through the song, so the BPM cell shows the variable
+		// label with the value in brackets.
+		work_tag: 'example-media-gamma',
+		tags: [],
+		title: 'Tempo Drift Suite',
+		author: 'Imaginary Orchestra',
+		bpm: 96,
+		variable_bpm: true
+	},
+	{
+		// Nobody has filled in the tempo yet, so the BPM cell falls back.
+		work_tag: 'example-media-delta',
+		tags: [],
+		title: 'Untitled Practice Loop',
+		author: 'Nonexistent Duo',
+		bpm: null,
+		variable_bpm: false
+	},
+	{
+		work_tag: 'example-media-epsilon',
+		tags: [],
+		title: 'Glass Harbour (Extended Mix)',
+		author: 'Made-Up Collective',
+		bpm: 140.5,
+		variable_bpm: false
+	},
+	{
+		// A single run of characters with no break opportunity. The table uses auto
+		// layout, so this title stretches the first column and squeezes the rest.
+		work_tag: 'example-media-zeta',
+		tags: [],
+		title:
+			'SUPERLONGUNBREAKABLETITLEWITHOUTANYWHITESPACEATALLTHATSTRETCHESTHEFIRSTCOLUMNVERYFARINDEED',
+		author: 'Invented Soloist',
+		bpm: 200,
+		variable_bpm: true
+	},
+	{
+		work_tag: 'example-media-eta',
+		tags: [],
+		title: 'Paper Lantern Parade',
+		author: 'Pretend Quartet',
+		bpm: 87,
+		variable_bpm: false
+	},
+	{
+		work_tag: 'example-media-theta',
+		tags: [],
+		title: 'Copper Wire Lullaby',
+		author: 'Hypothetical Band',
+		bpm: 112,
+		variable_bpm: false
+	}
+];
+
+/** A full page of songs, as the real list always is. */
+const songs: Song[] = Array.from({ length: batch_size }, (_, i) => ({
+	...templates[i % templates.length],
+	id: String(i + 1)
+}));
+
+const baseData = {
+	user: null,
+	stats,
+	query: '',
+	query_tags: '',
+	results: { items: songs, count: total_count },
+	batch_size,
+	bpm_range: null as [number, number] | null,
+	author: '',
+	head: {
+		title: m.mild_loud_shad_enchant({
+			type: m.mean_top_antelope_love(),
+			name: m.grand_nice_pony_belong()
+		})
+	}
+};
+
+const meta = {
+	component: Page,
+	args: {
+		data: baseData
+	}
+} satisfies Meta<ComponentProps<typeof Page>>;
+
+export default meta;
+type Story = StoryObj<ComponentProps<typeof Page>>;
+
+/** The unfiltered list: a full batch of songs with the pager below it. */
+export const Default: Story = {};
+
+/** A search narrows the list to one page, so the pager disappears. */
+export const Filtered: Story = {
+	args: {
+		data: {
+			...baseData,
+			query: 'lantern',
+			query_tags: 'example-song-tag',
+			author: 'Pretend Quartet',
+			bpm_range: [80, 120],
+			results: { items: [{ ...templates[6], id: '7' }], count: 1 }
+		}
+	}
+};
+
+/**
+ * The list itself is never empty, but a narrow enough search matches nothing,
+ * and that is the only way to see this state.
+ */
+export const FilteredNoResults: Story = {
+	args: {
+		data: {
+			...baseData,
+			query: 'no-such-song',
+			bpm_range: [400, 500],
+			results: { items: [], count: 0 }
+		}
+	}
+};


### PR DESCRIPTION
## What this does

This PR adds `frontend/src/routes/song/page.stories.ts`. It changes no production code.

The story covers:

- `Default` — a full batch of 20 songs with a total count of 6998, so the pager renders. This matches the real list, which is never short.
- `Filtered` — a search on the query, the tags, the author, and the BPM range. The result is one row, so the pager disappears.
- `FilteredNoResults` — a search that matches nothing. A filter is the only way to reach an empty list.

The fixture holds invented titles and authors only. It bakes in no real data. It uses no clock and no random values, so each render gives the same result.

One title is a single long run of characters with no whitespace. The rows also cover a fixed BPM, a variable BPM, and an unknown BPM.

## Why this is necessary

The `/song` table has the same layout defect as `/comments` (#984). The table uses auto layout, and `song.title` is free text. A long title with no break opportunity stretches the first column. We cannot fix the layout until the page has a story to check against. This PR only adds the story. A later PR fixes the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)