### PR TITLE
Organize coding agent configuration and shared MCP setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+	"enabledMcpjsonServers": ["storybook", "playwright", "chrome-devtools"],
+	"enabledPlugins": {
+		"frontend-design@claude-plugins-official": true
+	}
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,24 @@
+[mcp_servers.storybook]
+url = "http://localhost:6006/mcp"
+
+[mcp_servers.playwright]
+command = "bunx"
+args = [
+  "@playwright/mcp@latest",
+  "--headless",
+  "--isolated",
+  "--browser",
+  "chromium",
+  "--viewport-size",
+  "1280x720",
+  "--output-dir",
+  ".playwright-mcp",
+]
+
+[mcp_servers.chrome-devtools]
+command = "bunx"
+args = [
+  "chrome-devtools-mcp@latest",
+  "--headless=true",
+  "--isolated=true",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ Caddyfile
 docker-compose.dev.yml
 docker-compose.override.yml
 postgresql.conf
+.playwright-mcp
+.claude/plans
+.claude/settings.local.json
+.claude/worktrees/
+AGENTS.override.md
+CLAUDE.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,15 @@ Caddyfile
 docker-compose.dev.yml
 docker-compose.override.yml
 postgresql.conf
+
+# Agent tools
 .playwright-mcp
+
+# Claude Code
 .claude/plans
 .claude/settings.local.json
 .claude/worktrees/
-AGENTS.override.md
 CLAUDE.local.md
+
+# Shared agent overrides
+AGENTS.override.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,30 @@
+{
+	"mcpServers": {
+		"storybook": {
+			"type": "http",
+			"url": "http://localhost:6006/mcp"
+		},
+		"playwright": {
+			"command": "bunx",
+			"args": [
+				"@playwright/mcp@latest",
+				"--headless",
+				"--isolated",
+				"--browser",
+				"chromium",
+				"--viewport-size",
+				"1280x720",
+				"--output-dir",
+				".playwright-mcp"
+			]
+		},
+		"chrome-devtools": {
+			"command": "bunx",
+			"args": [
+				"chrome-devtools-mcp@latest",
+				"--headless=true",
+				"--isolated=true"
+			]
+		}
+	}
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,47 @@
 ## Tooling preferences
 
 - Use `jq` (not `python3 -c`) when querying or inspecting JSON files.
+
+## Agent configuration
+
+- `AGENTS.md` is the canonical shared instruction file. Keep `CLAUDE.md` as a relative symlink to the `AGENTS.md` in the same directory.
+- Put personal or machine-specific instructions in the git-ignored `AGENTS.override.md`. Keep `CLAUDE.local.md` as a relative symlink to `AGENTS.override.md` so Codex and Claude Code read the same local instructions.
+- Shared Claude Code settings live in `.claude/settings.json`; personal permissions and overrides belong in the git-ignored `.claude/settings.local.json`.
+- Keep `.mcp.json` and `.codex/config.toml` aligned when adding or changing shared MCP servers. The former configures Claude Code and the latter configures Codex.
+
+## Agent workflow
+
+- For any task large enough to span more than one area of the codebase, plan first and implement second, with different models on each side:
+  1. **Plan with Fable** — spawn an agent with `model: fable` to survey the codebase and produce the overall plan (work breakdown, file-level scope of each piece, and the order/dependencies between them).
+  2. **Implement with Opus** — hand each piece of that plan to its own Opus agent. Give every agent the plan's scope for its piece so the pieces stay disjoint, and run independent pieces concurrently.
+
+## MCP servers
+
+`.mcp.json` and `.codex/config.toml` at the repository root define the MCP servers agents are expected to use. Claude Code enables the servers from `.mcp.json` via `enabledMcpjsonServers` in `.claude/settings.json`; Codex reads `.codex/config.toml`.
+
+### `storybook` — writing and testing stories
+
+Provided by the `@storybook/addon-mcp` addon registered in `frontend/.storybook/main.ts`, served over HTTP at `http://localhost:6006/mcp`.
+
+- **The Storybook dev server must be running for this server to work.** Start it first with `bun run storybook:agent` from `frontend/` (see `frontend/AGENTS.md`). When Storybook is not running, the server is simply unreachable.
+- Use `get-storybook-story-instructions` before writing or editing components and stories, `preview-stories` after any change that affects how the UI looks, and `run-story-tests` to validate.
+
+### `playwright` — driving a browser and taking screenshots
+
+- Runs headless Chrome for Testing (`--browser chromium`) in an isolated profile at a 1280x720 viewport.
+- Screenshots and other artifacts are written to `.playwright-mcp/`, which is git-ignored. Note that `--output-dir` only applies when the tool call omits a filename; passing an explicit relative `filename` resolves it against the process working directory instead, which litters the repository. Prefer omitting `filename`.
+
+### `chrome-devtools` — performance and network analysis
+
+- Use this only when you need what Playwright cannot give you: Core Web Vitals, Lighthouse audits, performance traces, or detailed network/console inspection. For ordinary navigation and screenshots, use `playwright`.
+- **Requires a real Google Chrome installation** (`/opt/google/chrome/chrome` on Linux). It does not download a browser for you. On Arch, install the AUR `google-chrome` package.
+
+### Browser dependencies on Linux
+
+The Chromium builds Playwright downloads are dynamically linked against system libraries that a minimal Linux install does not have. `playwright install-deps` only emits `apt-get` commands and is useless on non-Debian distributions. On Arch, install these instead:
+
+```
+paru -S --needed libxcomposite libxdamage libxfixes libxrandr libxkbcommon alsa-lib at-spi2-core mesa
+```
+
+Verify with `ldd ~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome | grep "not found"` — it should print nothing. When these are missing, the browser fails to launch with the unhelpful message `Target page, context or browser has been closed`.

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -8,7 +8,8 @@ export default defineMain({
 		'@storybook/addon-docs',
 		'@storybook/addon-a11y',
 		'@storybook/addon-themes',
-		'@storybook/addon-vitest'
+		'@storybook/addon-vitest',
+		'@storybook/addon-mcp'
 	],
 	staticDirs: [
 		{

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -61,6 +61,17 @@ All three commands must succeed without errors before committing. Do not skip or
 
 - When a coding agent starts Storybook, always use `bun run storybook:agent`, not `bun run storybook`. It runs with `--quiet --ci --disable-telemetry --no-version-updates` to minimize console output and token usage, and it does not pass `--no-open`, so it may open a browser automatically.
 - `bun run storybook` (without those flags) is reserved for a human developer running Storybook interactively.
+- The dev server also exposes the `storybook` MCP server at `http://localhost:6006/mcp` via the `@storybook/addon-mcp` addon, so start Storybook before using those MCP tools. See the MCP servers section of the repository root `AGENTS.md`.
+
+### Running story tests
+
+`bun run test-storybook` (`vitest --project=storybook`) drives a real headless Chromium through Playwright, so it needs the browser binaries and their system libraries:
+
+```
+bunx playwright install chromium
+```
+
+If that download stalls — it has, for tens of minutes at a time, while `curl` on the same URL saturates the link — get the URLs from `bunx playwright install --dry-run chromium`, fetch the zips with `curl -L`, extract them into the printed install locations under `~/.cache/ms-playwright/`, and `touch INSTALLATION_COMPLETE` in each. See the root `AGENTS.md` for the system libraries the browser needs.
 
 ## Coding
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -37,6 +37,7 @@
         "@iconify/tailwind4": "^1.2.3",
         "@storybook/addon-a11y": "^10.3.5",
         "@storybook/addon-docs": "^10.3.5",
+        "@storybook/addon-mcp": "^0.7.0",
         "@storybook/addon-svelte-csf": "^5.1.2",
         "@storybook/addon-themes": "^10.3.5",
         "@storybook/addon-vitest": "10.3.5",
@@ -495,6 +496,8 @@
 
     "@storybook/addon-docs": ["@storybook/addon-docs@10.3.5", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/csf-plugin": "10.3.5", "@storybook/icons": "^2.0.1", "@storybook/react-dom-shim": "10.3.5", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.3.5" } }, "sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA=="],
 
+    "@storybook/addon-mcp": ["@storybook/addon-mcp@0.7.0", "", { "dependencies": { "@storybook/mcp": "0.8.0", "@tmcp/adapter-valibot": "^0.1.5", "@tmcp/transport-http": "^0.8.5", "picoquery": "^2.5.0", "tmcp": "^1.19.4", "valibot": "1.2.0" }, "peerDependencies": { "@storybook/addon-vitest": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0", "storybook": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0" }, "optionalPeers": ["@storybook/addon-vitest"] }, "sha512-f/IWGRMzWynBg5kDJ3DYvvnafuSX88kykGNFzzLOlkLVpfxEZoAmQF6AS47tw25GuH6EFIqSo6ZDBLHLVyZ/IQ=="],
+
     "@storybook/addon-svelte-csf": ["@storybook/addon-svelte-csf@5.1.2", "", { "dependencies": { "@storybook/csf": "^0.1.13", "dedent": "^1.5.3", "es-toolkit": "^1.26.1", "esrap": "^1.2.2", "magic-string": "^0.30.12", "svelte-ast-print": "^0.4.0", "zimmerframe": "^1.1.2" }, "peerDependencies": { "@storybook/svelte": "^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0", "@sveltejs/vite-plugin-svelte": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "storybook": "^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0", "svelte": "^5.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-NpImknEb48J7yr/ArTYpvhDSvGUrgm5Nuybu9PCicjSKTACsXX7cln2R19572ORtns399RTE+t20BBOKxSPm2g=="],
 
     "@storybook/addon-themes": ["@storybook/addon-themes@10.3.5", "", { "dependencies": { "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.3.5" } }, "sha512-Mv+C7GuZ0MhGRx5C+rv8sCEjgYsDTLBvq68101V0s8Vwh3gKd6W9cbS31HoOeLAiIMiPPZ8C1iWudA3Oumdtlw=="],
@@ -510,6 +513,8 @@
     "@storybook/global": ["@storybook/global@5.0.0", "", {}, "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="],
 
     "@storybook/icons": ["@storybook/icons@2.0.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg=="],
+
+    "@storybook/mcp": ["@storybook/mcp@0.8.0", "", { "dependencies": { "@tmcp/adapter-valibot": "^0.1.5", "@tmcp/transport-http": "^0.8.5", "tmcp": "^1.19.4", "valibot": "1.2.0" } }, "sha512-G+XDgoWGrE98moXqKSee8fQyMQxoIWxRAbPG8r/HQ95pKodratevDqNyOgW+t6ZigM6AAVN1WHiFc5MI+hc8sg=="],
 
     "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.3.5", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.5" } }, "sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g=="],
 
@@ -568,6 +573,12 @@
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@thisux/sveltednd": ["@thisux/sveltednd@0.0.20", "", { "dependencies": { "@thisux/sveltednd": "^0.0.18" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-VE0HopIlHIvNOfSZ1SsiIzl1AmTU0VSd2Nz2Q2nIdqIUsT/UP4hiLw2ed2jFqTKTbqC+kbCYL9vuBpkYnEw+Kw=="],
+
+    "@tmcp/adapter-valibot": ["@tmcp/adapter-valibot@0.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@valibot/to-json-schema": "^1.3.0", "valibot": "^1.1.0" }, "peerDependencies": { "tmcp": "^1.17.0" } }, "sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA=="],
+
+    "@tmcp/session-manager": ["@tmcp/session-manager@0.2.2", "", { "peerDependencies": { "tmcp": "^1.16.3" } }, "sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ=="],
+
+    "@tmcp/transport-http": ["@tmcp/transport-http@0.8.6", "", { "dependencies": { "@tmcp/session-manager": "^0.2.2", "esm-env": "^1.2.2" }, "peerDependencies": { "@tmcp/auth": "^0.3.3 || ^0.4.0", "tmcp": "^1.18.0" }, "optionalPeers": ["@tmcp/auth"] }, "sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
@@ -702,6 +713,8 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
+
+    "@valibot/to-json-schema": ["@valibot/to-json-schema@1.7.1", "", { "peerDependencies": { "valibot": "^1.4.0" } }, "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A=="],
 
     "@vitest/browser": ["@vitest/browser@4.1.10", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng=="],
 
@@ -1191,6 +1204,8 @@
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
+    "json-rpc-2.0": ["json-rpc-2.0@1.7.1", "", {}, "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg=="],
+
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
@@ -1453,6 +1468,8 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "picoquery": ["picoquery@2.5.0", "", {}, "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g=="],
+
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
@@ -1599,6 +1616,8 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "sqids": ["sqids@0.3.0", "", {}, "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw=="],
+
     "sqlite-wasm-kysely": ["sqlite-wasm-kysely@0.3.0", "", { "dependencies": { "@sqlite.org/sqlite-wasm": "^3.48.0-build2" }, "peerDependencies": { "kysely": "*" } }, "sha512-TzjBNv7KwRw6E3pdKdlRyZiTmUIE0UttT/Sl56MVwVARl/u5gp978KepazCJZewFUnlWHz9i3NQd4kOtP/Afdg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
@@ -1669,6 +1688,8 @@
 
     "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
+    "tmcp": ["tmcp@1.19.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "json-rpc-2.0": "^1.7.1", "sqids": "^0.3.0", "uri-template-matcher": "^1.1.1", "valibot": "^1.1.0" } }, "sha512-fMoUJ3Gef9iA0yKZNeW2SQCCKTluCwghUyOz/qxPS8XxrQk6Jlw4lgql3S+s6L//FteLeSJ7erKxMWl727mZoQ=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
@@ -1723,6 +1744,8 @@
 
     "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
 
+    "uri-template-matcher": ["uri-template-matcher@1.1.2", "", {}, "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ=="],
+
     "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
@@ -1730,6 +1753,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
 		"@iconify/tailwind4": "^1.2.3",
 		"@storybook/addon-a11y": "^10.3.5",
 		"@storybook/addon-docs": "^10.3.5",
+		"@storybook/addon-mcp": "^0.7.0",
 		"@storybook/addon-svelte-csf": "^5.1.2",
 		"@storybook/addon-themes": "^10.3.5",
 		"@storybook/addon-vitest": "10.3.5",


### PR DESCRIPTION
## Summary

- make `AGENTS.md` the canonical shared instruction source and document the local `AGENTS.override.md` / `CLAUDE.local.md` symlink convention
- ignore local agent plans, worktrees, permissions, and override files
- add shared Claude Code and Codex MCP configuration for Storybook, Playwright, and Chrome DevTools
- expose Storybook MCP through `@storybook/addon-mcp` and document its setup

## Testing

- `jq empty .mcp.json .claude/settings.json`
- `codex mcp list`
- `bun run format`
- `bun run lint` (passes with one existing warning)
- `bun run check` (0 errors, existing warnings only)
- `bun run build-storybook`